### PR TITLE
Feat/us 012 pipeline infrastructure

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -2,7 +2,7 @@ fileignoreconfig:
 - filename: .github/workflows/project-sync.yml
   checksum: f817f70193e5d38e8b49f7a2b79f79e6ad840d79ad0079b936760cdb3c22109
 - filename: TODO.md
-  checksum: 5eee2a7801ea5074e32e34a25d050e0792297de03974a7a25a887e51c73ee3ee
+  checksum: 0240fb9bfb9678ffecdcfdc37d10fa13389b6ba141f9ca6d4c166edbb053960a
 - filename: .env.example
   checksum: 300c0cac552c54660180ce29f391bc21617ac74830be6332684f5bef55de301c
 - filename: backend/alembic/env.py

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A web application that converts architecture drawings (PDFs) into editable 2D or 3D CAD models in DWG (and DXF) format. Built with a modern, decoupled architecture that separates the user-facing experience (Next.js) from the compute-heavy image processing and ML pipeline (Python/FastAPI).
 
-> **Status:** Implementation in progress — Phase 1 (scaffolding & upload flow) is complete and running. All 5 Docker services (frontend, backend, worker, postgres, redis) are operational. See the phased roadmap at the bottom for what's next.
+> **Status:** Implementation in progress — Phase 1 (scaffolding & upload flow) is complete and running, and Phase 2 pipeline infrastructure is in review. All 5 Docker services (frontend, backend, worker, postgres, redis) are operational. See the phased roadmap at the bottom for what's next.
 >
 > 📋 **Looking for the execution plan?** See [TODO.md](./TODO.md) — a complete breakdown of 28 user stories and 92 actionable tasks managed as **GitHub Issues** via the `gh` CLI and the GitHub MCP server.
 
@@ -235,6 +235,7 @@ ai-file-converter/
 │   │   │       └── jobs_stream.py # GET /jobs/{id}/stream (SSE)
 │   │   ├── core/                   # Config (pydantic-settings), database
 │   │   ├── models/                 # SQLAlchemy ORM (Job model)
+│   │   ├── pipeline/               # PipelineContext, PipelineStep, orchestrator, progress publisher
 │   │   ├── schemas/                # Pydantic request/response models
 │   │   ├── storage/                # Storage adapter (LocalStorage, ABC)
 │   │   └── tasks/                  # Celery app + placeholder pipeline
@@ -269,6 +270,12 @@ class PipelineStep(ABC):
 ```
 
 Concrete implementations: `PyMuPDFParser`, `OpenCVPreprocessor`, `YOLOSegmenter`, `ezdxfWriter`, etc. New approaches drop in without changing `Pipeline.run()`.
+
+Implemented foundation:
+- `backend/app/pipeline/context.py` defines the shared `PipelineContext` dataclass.
+- `backend/app/pipeline/steps/base.py` defines the `PipelineStep` ABC.
+- `backend/app/pipeline/orchestrator.py` provides `Pipeline.run()` for ordered step execution.
+- `backend/app/pipeline/progress.py` provides Redis Pub/Sub progress publishing.
 
 ### 8.2 Observer / Pub-Sub — Progress Reporting
 Workers publish progress events to **Redis Pub/Sub**. The FastAPI SSE endpoint subscribes and forwards events to the browser. This decouples the worker from the web layer and lets multiple workers report independently.
@@ -340,6 +347,8 @@ result = Pipeline([
 - [x] Conversion options UI (2D/3D, DPI, floor height, output format)
 
 ### Phase 2 — PDF Parsing & Preprocessing
+- [x] Pluggable backend pipeline framework (`PipelineContext`, `PipelineStep`, `Pipeline.run()`)
+- [x] Redis Pub/Sub progress publisher for pipeline steps
 - PyMuPDF integration → extract pages as images
 - OpenCV preprocessing pipeline
 - Page preview in frontend
@@ -577,4 +586,4 @@ See [TODO.md §A](./TODO.md) for the full GitHub issue management playbook, incl
 
 ---
 
-*Document version 0.2 — updated to reflect Phase 1 implementation (scaffolding & upload flow).*
+*Document version 0.3 — updated to reflect Phase 1 implementation and Phase 2 pipeline infrastructure.*

--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,10 @@
 # TODO — AI File Converter Implementation Tracker
+[![CI](https://github.com/Josh-Uvi/DrawLift/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Josh-Uvi/DrawLift/actions/workflows/ci.yml)
 
 > Living document that decomposes the [README.md](./README.md) architecture into actionable work.
 > Structure follows GitHub Issues–style tracking: **Stages → Epics (Milestones/Labels) → User Stories (Issues) → Tasks (sub-checklists)**.
 > Each item includes priority, effort estimate, acceptance criteria, and dependencies.
 > Issue management is driven by the **GitHub CLI (`gh`)** and/or the **GitHub MCP server** — no Linear dependency.
-
----
 
 ## Conventions
 
@@ -40,7 +39,7 @@
 |---|---|---|---|---|---|
 | 0 | **Bootstrap** | Repo, tooling, CI scaffold | 🚧 In Progress | 4 | 12 |
 | 1 | **Phase 1 — MVP Skeleton** | Upload + queue + job tracking | 👀 In Review | 5 | 18 |
-| 2 | **Phase 2 — PDF Parsing** | Extract & preview page images | ⬜ Backlog | 4 | 14 |
+| 2 | **Phase 2 — PDF Parsing** | Extract & preview page images | 🚧 In Progress | 4 | 14 |
 | 3 | **Phase 3 — 2D Vectorization** | PDF → DXF (core value) | ⬜ Backlog | 5 | 16 |
 | 4 | **Phase 4 — 3D Extrusion** | Walls → 3D model | ⬜ Backlog | 4 | 12 |
 | 5 | **Phase 5 — Polish & DWG** | Production-ready with DWG export | ⬜ Backlog | 6 | 20 |
@@ -55,6 +54,7 @@
 |---|---|---|---|---|
 | 2025-07-22 | Stage 0 — US-001 | [#30](https://github.com/Josh-Uvi/DrawLift/pull/30) (merged) | US-001 | Monorepo layout, `.gitignore`, `LICENSE`, `README.md` |
 | 2025-07-23 | Stage 0 + Stage 1 — Phase 1 | [#31](https://github.com/Josh-Uvi/DrawLift/pull/31) (open) | US-002 → US-011 | Full Phase 1 implementation: FastAPI backend, Next.js 14 frontend, Docker Compose, CI, Celery, SSE streaming, and pre-commit quality gates. |
+| 2026-07-23 | Stage 2 — US-012 | Not opened | US-012 | Pipeline framework, context dataclass, ordered orchestrator, and Redis Pub/Sub progress publisher prepared on `feat/us-012-pipeline-infrastructure`. |
 
 ---
 
@@ -236,17 +236,17 @@
 ## Epic 2.1 — Pipeline Infrastructure
 
 ### US-012 · As a backend dev, I want a pluggable pipeline framework
-- **Priority:** P0 · **Effort:** M · **Status:** ⬜ Backlog · **Labels:** `area:backend`, `epic:p2-pdf`
+- **Priority:** P0 · **Effort:** M · **Status:** 👀 In Review · **Labels:** `area:backend`, `epic:p2-pdf`
 - **Acceptance Criteria:**
-  - [ ] `PipelineStep` ABC defined
-  - [ ] `PipelineContext` dataclass defined
-  - [ ] `Pipeline.run()` executes steps in order
-  - [ ] Each step can publish progress to Redis
+  - [x] `PipelineStep` ABC defined
+  - [x] `PipelineContext` dataclass defined
+  - [x] `Pipeline.run()` executes steps in order
+  - [x] Each step can publish progress to Redis
 - **Tasks:**
-  - [ ] T-039 — Create `backend/app/pipeline/steps/base.py` with `PipelineStep` ABC
-  - [ ] T-040 — Create `backend/app/pipeline/context.py`
-  - [ ] T-041 — Create `backend/app/pipeline/__init__.py` orchestrator
-  - [ ] T-042 — Add progress publishing helper (Redis Pub/Sub)
+  - [x] T-039 — Create `backend/app/pipeline/steps/base.py` with `PipelineStep` ABC
+  - [x] T-040 — Create `backend/app/pipeline/context.py`
+  - [x] T-041 — Create `backend/app/pipeline/__init__.py` orchestrator
+  - [x] T-042 — Add progress publishing helper (Redis Pub/Sub)
 
 ### US-013 · As a backend dev, I want PyMuPDF-based PDF page extraction
 - **Priority:** P0 · **Effort:** M · **Status:** ⬜ Backlog · **Labels:** `area:backend`, `epic:p2-pdf`
@@ -737,4 +737,4 @@ Stage 5 (Polish)                      ▼
 
 ---
 
-*Document version 0.2 — updated 2025-07-23 to reflect Phase 1 implementation (PR [#30](https://github.com/Josh-Uvi/DrawLift/pull/30) + [#31](https://github.com/Josh-Uvi/DrawLift/pull/31)). US-001 ✅ Done; US-002 → US-011 👀 In Review.*
+*Document version 0.3 — updated 2026-07-23 to reflect Phase 1 implementation and US-012 pipeline infrastructure progress. US-001 ✅ Done; US-002 → US-012 👀 In Review.*

--- a/backend/app/pipeline/__init__.py
+++ b/backend/app/pipeline/__init__.py
@@ -1,0 +1,7 @@
+"""Pluggable conversion pipeline framework."""
+
+from app.pipeline.context import PipelineContext, ProgressPublisher
+from app.pipeline.orchestrator import Pipeline, create_pipeline
+from app.pipeline.steps.base import PipelineStep
+
+__all__ = ["Pipeline", "PipelineContext", "PipelineStep", "ProgressPublisher", "create_pipeline"]

--- a/backend/app/pipeline/__init__.py
+++ b/backend/app/pipeline/__init__.py
@@ -2,6 +2,16 @@
 
 from app.pipeline.context import PipelineContext, ProgressPublisher
 from app.pipeline.orchestrator import Pipeline, create_pipeline
+from app.pipeline.progress import ProgressEvent, RedisProgressPublisher, get_progress_publisher
 from app.pipeline.steps.base import PipelineStep
 
-__all__ = ["Pipeline", "PipelineContext", "PipelineStep", "ProgressPublisher", "create_pipeline"]
+__all__ = [
+    "Pipeline",
+    "PipelineContext",
+    "PipelineStep",
+    "ProgressEvent",
+    "ProgressPublisher",
+    "RedisProgressPublisher",
+    "create_pipeline",
+    "get_progress_publisher",
+]

--- a/backend/app/pipeline/context.py
+++ b/backend/app/pipeline/context.py
@@ -1,0 +1,84 @@
+"""Shared state passed between conversion pipeline steps."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+
+def _empty_config() -> dict[str, Any]:
+    """Return an empty conversion config mapping."""
+    return {}
+
+
+def _empty_path_list() -> list[Path]:
+    """Return an empty list of filesystem paths."""
+    return []
+
+
+def _empty_any_list() -> list[Any]:
+    """Return an empty list for future pipeline artifacts."""
+    return []
+
+
+def _empty_any_mapping() -> dict[str, Any]:
+    """Return an empty mapping for future pipeline artifacts."""
+    return {}
+
+
+class ProgressPublisher(Protocol):
+    """Protocol for publishing pipeline progress events."""
+
+    def publish(
+        self,
+        *,
+        job_id: str,
+        status: str,
+        progress: int,
+        step: str,
+        message: str | None = None,
+    ) -> None:
+        """Publish a progress update for a pipeline step."""
+
+
+@dataclass
+class PipelineContext:
+    """Mutable pipeline state that each conversion step receives and returns.
+
+    The fields intentionally use flexible container types so Phase 2+ steps can
+    attach PDF page images, OpenCV arrays, ML masks, CAD primitives, and output
+    paths without coupling this foundational package to heavy optional
+    dependencies such as NumPy, OpenCV, PyMuPDF, or ezdxf.
+    """
+
+    job_id: str
+    input_path: Path
+    config: dict[str, Any] = field(default_factory=_empty_config)
+    page_images: list[Path] = field(default_factory=_empty_path_list)
+    preprocessed: list[Any] = field(default_factory=_empty_any_list)
+    masks: dict[str, Any] = field(default_factory=_empty_any_mapping)
+    primitives: list[Any] = field(default_factory=_empty_any_list)
+    output_path: Path | None = None
+    metadata: dict[str, Any] = field(default_factory=_empty_any_mapping)
+    progress_publisher: ProgressPublisher | None = None
+
+    def publish_progress(
+        self,
+        *,
+        status: str,
+        progress: int,
+        step: str,
+        message: str | None = None,
+    ) -> None:
+        """Publish a progress event when a publisher is attached to the context."""
+        if self.progress_publisher is None:
+            return
+
+        self.progress_publisher.publish(
+            job_id=self.job_id,
+            status=status,
+            progress=progress,
+            step=step,
+            message=message,
+        )

--- a/backend/app/pipeline/orchestrator.py
+++ b/backend/app/pipeline/orchestrator.py
@@ -1,0 +1,65 @@
+"""Pipeline orchestration for ordered conversion steps."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Self
+
+from app.pipeline.context import PipelineContext
+from app.pipeline.steps.base import PipelineStep
+
+
+@dataclass(frozen=True)
+class Pipeline:
+    """Run a sequence of pluggable pipeline steps in order."""
+
+    steps: Sequence[PipelineStep]
+    publish_step_progress: bool = True
+
+    def run(self, context: PipelineContext) -> PipelineContext:
+        """Execute configured steps sequentially and return the final context."""
+        current_context = context
+        total_steps = len(self.steps)
+
+        for index, step in enumerate(self.steps, start=1):
+            if self.publish_step_progress:
+                step.publish_progress(
+                    current_context,
+                    progress=self._calculate_progress(index - 1, total_steps),
+                    message="started",
+                )
+
+            current_context = step.execute(current_context)
+
+            if self.publish_step_progress:
+                step.publish_progress(
+                    current_context,
+                    progress=self._resolve_step_progress(step, index, total_steps),
+                    message="completed",
+                )
+
+        return current_context
+
+    @classmethod
+    def from_steps(cls, *steps: PipelineStep, publish_step_progress: bool = True) -> Self:
+        """Build a pipeline from positional steps for concise call sites."""
+        return cls(steps=steps, publish_step_progress=publish_step_progress)
+
+    @staticmethod
+    def _calculate_progress(completed_steps: int, total_steps: int) -> int:
+        """Calculate percentage progress from completed and total step counts."""
+        if total_steps == 0:
+            return 0
+        return round((completed_steps / total_steps) * 100)
+
+    def _resolve_step_progress(self, step: PipelineStep, index: int, total_steps: int) -> int:
+        """Prefer explicit step progress; otherwise derive progress from position."""
+        if step.progress is not None:
+            return step.progress
+        return self._calculate_progress(index, total_steps)
+
+
+def create_pipeline(*steps: PipelineStep, publish_step_progress: bool = True) -> Pipeline:
+    """Factory helper for constructing pipelines from individual steps."""
+    return Pipeline.from_steps(*steps, publish_step_progress=publish_step_progress)

--- a/backend/app/pipeline/progress.py
+++ b/backend/app/pipeline/progress.py
@@ -1,0 +1,107 @@
+"""Redis Pub/Sub progress publishing for conversion pipelines."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from functools import lru_cache
+from typing import Any, Protocol, cast
+
+import redis
+
+from app.core.config import get_settings
+
+
+class RedisPublishClient(Protocol):
+    """Minimal Redis client interface needed by the progress publisher."""
+
+    def publish(self, channel: str, message: str) -> Any:
+        """Publish a message to a Redis Pub/Sub channel."""
+
+
+def _empty_metadata() -> dict[str, Any]:
+    """Return an empty event metadata mapping."""
+    return {}
+
+
+@dataclass(frozen=True)
+class ProgressEvent:
+    """Serializable progress update emitted by pipeline steps."""
+
+    job_id: str
+    status: str
+    progress: int
+    step: str
+    message: str | None = None
+    metadata: dict[str, Any] = field(default_factory=_empty_metadata)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the event to the JSON payload consumed by the SSE endpoint."""
+        payload: dict[str, Any] = {
+            "job_id": self.job_id,
+            "status": self.status,
+            "progress": self.progress,
+            "step": self.step,
+        }
+        if self.message is not None:
+            payload["message"] = self.message
+        if self.metadata:
+            payload["metadata"] = self.metadata
+        return payload
+
+    def to_json(self) -> str:
+        """Serialize the progress event as compact JSON."""
+        return json.dumps(self.to_dict(), separators=(",", ":"))
+
+
+@dataclass
+class RedisProgressPublisher:
+    """Publish pipeline progress events to Redis Pub/Sub channels."""
+
+    redis_url: str | None = None
+    redis_client: RedisPublishClient | None = None
+    channel_prefix: str = "job"
+
+    def __post_init__(self) -> None:
+        """Create a Redis client when one was not injected by the caller."""
+        if self.redis_client is None:
+            url = self.redis_url or get_settings().REDIS_URL
+            self.redis_client = cast(RedisPublishClient, redis.from_url(url))
+
+    def publish(
+        self,
+        *,
+        job_id: str,
+        status: str,
+        progress: int,
+        step: str,
+        message: str | None = None,
+    ) -> None:
+        """Publish a progress event to the job-specific Redis channel."""
+        event = ProgressEvent(
+            job_id=job_id,
+            status=status,
+            progress=self._normalize_progress(progress),
+            step=step,
+            message=message,
+        )
+        redis_client = self.redis_client
+        if redis_client is None:
+            raise RuntimeError("Redis progress publisher was not initialised")
+
+        redis_client.publish(self.channel_for(job_id), event.to_json())
+
+    def channel_for(self, job_id: str) -> str:
+        """Return the Redis Pub/Sub channel name for a job."""
+        return f"{self.channel_prefix}:{job_id}"
+
+    @staticmethod
+    def _normalize_progress(progress: int) -> int:
+        """Clamp progress into the 0-100 range expected by API clients."""
+        return max(0, min(progress, 100))
+
+
+@lru_cache
+def get_progress_publisher() -> RedisProgressPublisher:
+    """Return a cached Redis-backed progress publisher for worker code."""
+    return RedisProgressPublisher()

--- a/backend/app/pipeline/steps/__init__.py
+++ b/backend/app/pipeline/steps/__init__.py
@@ -1,0 +1,5 @@
+"""Pipeline step interfaces and concrete step implementations."""
+
+from app.pipeline.steps.base import PipelineStep
+
+__all__ = ["PipelineStep"]

--- a/backend/app/pipeline/steps/base.py
+++ b/backend/app/pipeline/steps/base.py
@@ -1,0 +1,37 @@
+"""Base interfaces for pluggable conversion pipeline steps."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from app.pipeline.context import PipelineContext
+
+
+class PipelineStep(ABC):
+    """Abstract base class for a single conversion pipeline step."""
+
+    name: str
+    progress: int | None = None
+
+    @abstractmethod
+    def execute(self, context: PipelineContext) -> PipelineContext:
+        """Execute the step and return the updated pipeline context."""
+
+    def publish_progress(
+        self,
+        context: PipelineContext,
+        *,
+        status: str = "processing",
+        progress: int | None = None,
+        message: str | None = None,
+    ) -> None:
+        """Publish this step's progress through the context publisher, if present."""
+        resolved_progress = (
+            self.progress if progress is None and self.progress is not None else progress
+        )
+        context.publish_progress(
+            status=status,
+            progress=resolved_progress or 0,
+            step=self.name,
+            message=message,
+        )

--- a/backend/app/tasks/placeholder.py
+++ b/backend/app/tasks/placeholder.py
@@ -1,14 +1,10 @@
 """Placeholder Celery task that simulates the conversion pipeline."""
 
-import json
 import time
+from typing import Any
 
-import redis
-
-from app.core.config import get_settings
+from app.pipeline.progress import get_progress_publisher
 from app.tasks.celery_app import celery_app
-
-settings = get_settings()
 
 
 def publish_progress(job_id: str, status: str, progress: int, step: str) -> None:
@@ -20,21 +16,16 @@ def publish_progress(job_id: str, status: str, progress: int, step: str) -> None
         progress: Progress percentage (0-100).
         step: The current pipeline step name.
     """
-    r = redis.from_url(settings.REDIS_URL)
-    channel = f"job:{job_id}"
-    payload = json.dumps(
-        {
-            "job_id": job_id,
-            "status": status,
-            "progress": progress,
-            "step": step,
-        }
+    get_progress_publisher().publish(
+        job_id=job_id,
+        status=status,
+        progress=progress,
+        step=step,
     )
-    r.publish(channel, payload)
 
 
 @celery_app.task(name="app.tasks.placeholder.process_job")
-def process_job(job_id: str, config: dict) -> str:
+def process_job(job_id: str, config: dict[str, Any]) -> str:
     """Simulate the conversion pipeline with progress updates.
 
     Args:

--- a/backend/tests/test_pipeline.py
+++ b/backend/tests/test_pipeline.py
@@ -1,0 +1,141 @@
+"""Tests for the pluggable pipeline framework."""
+
+from pathlib import Path
+
+from app.pipeline import Pipeline, PipelineContext, PipelineStep, create_pipeline
+
+
+class RecordingPublisher:
+    """In-memory progress publisher used by pipeline tests."""
+
+    def __init__(self) -> None:
+        self.events: list[dict[str, object]] = []
+
+    def publish(
+        self,
+        *,
+        job_id: str,
+        status: str,
+        progress: int,
+        step: str,
+        message: str | None = None,
+    ) -> None:
+        self.events.append(
+            {
+                "job_id": job_id,
+                "status": status,
+                "progress": progress,
+                "step": step,
+                "message": message,
+            }
+        )
+
+
+class RecordingStep(PipelineStep):
+    """Pipeline step that records execution order in context metadata."""
+
+    def __init__(self, name: str, progress: int | None = None) -> None:
+        self.name = name
+        self.progress = progress
+
+    def execute(self, context: PipelineContext) -> PipelineContext:
+        order = context.metadata.setdefault("order", [])
+        assert isinstance(order, list)
+        order.append(self.name)
+        return context
+
+
+def test_pipeline_context_defaults_to_empty_containers() -> None:
+    """PipelineContext provides safe empty defaults for future steps."""
+    context = PipelineContext(job_id="job-123", input_path=Path("input.pdf"))
+
+    assert context.page_images == []
+    assert context.preprocessed == []
+    assert context.masks == {}
+    assert context.primitives == []
+    assert context.output_path is None
+
+
+def test_pipeline_run_executes_steps_in_order() -> None:
+    """Pipeline.run executes each step sequentially and returns the final context."""
+    context = PipelineContext(job_id="job-123", input_path=Path("input.pdf"))
+    pipeline = Pipeline([RecordingStep("parse"), RecordingStep("preprocess")])
+
+    result = pipeline.run(context)
+
+    assert result is context
+    assert result.metadata["order"] == ["parse", "preprocess"]
+
+
+def test_create_pipeline_accepts_positional_steps() -> None:
+    """create_pipeline is a convenience factory around Pipeline.from_steps."""
+    pipeline = create_pipeline(RecordingStep("parse"), RecordingStep("preprocess"))
+
+    assert [step.name for step in pipeline.steps] == ["parse", "preprocess"]
+
+
+def test_steps_can_publish_progress_via_context() -> None:
+    """Each step can publish progress through the context's attached publisher."""
+    publisher = RecordingPublisher()
+    context = PipelineContext(
+        job_id="job-123",
+        input_path=Path("input.pdf"),
+        progress_publisher=publisher,
+    )
+    step = RecordingStep("parse", progress=20)
+
+    step.publish_progress(context)
+
+    assert publisher.events == [
+        {
+            "job_id": "job-123",
+            "status": "processing",
+            "progress": 20,
+            "step": "parse",
+            "message": None,
+        }
+    ]
+
+
+def test_pipeline_publishes_start_and_completion_progress_for_steps() -> None:
+    """The orchestrator emits progress events around each step execution."""
+    publisher = RecordingPublisher()
+    context = PipelineContext(
+        job_id="job-123",
+        input_path=Path("input.pdf"),
+        progress_publisher=publisher,
+    )
+    pipeline = Pipeline([RecordingStep("parse", progress=20), RecordingStep("preprocess")])
+
+    pipeline.run(context)
+
+    assert publisher.events == [
+        {
+            "job_id": "job-123",
+            "status": "processing",
+            "progress": 0,
+            "step": "parse",
+            "message": "started",
+        },
+        {
+            "job_id": "job-123",
+            "status": "processing",
+            "progress": 20,
+            "step": "parse",
+            "message": "completed",
+        },
+        {
+            "job_id": "job-123",
+            "status": "processing",
+            "progress": 50,
+            "step": "preprocess",
+            "message": "started",
+        },
+        {
+            "job_id": "job-123",
+            "status": "processing",
+            "progress": 100,
+            "step": "preprocess",
+            "message": "completed",
+        },
+    ]

--- a/backend/tests/test_pipeline_progress.py
+++ b/backend/tests/test_pipeline_progress.py
@@ -1,0 +1,84 @@
+"""Tests for Redis-backed pipeline progress publishing."""
+
+import json
+
+from app.pipeline.progress import ProgressEvent, RedisProgressPublisher
+
+
+class FakeRedisClient:
+    """In-memory Redis-like client that records publish calls."""
+
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str]] = []
+
+    def publish(self, channel: str, message: str) -> int:
+        self.messages.append((channel, message))
+        return 1
+
+
+def test_progress_event_serializes_required_fields() -> None:
+    """ProgressEvent serializes to the SSE-compatible payload shape."""
+    event = ProgressEvent(job_id="job-123", status="processing", progress=42, step="parse")
+
+    assert json.loads(event.to_json()) == {
+        "job_id": "job-123",
+        "status": "processing",
+        "progress": 42,
+        "step": "parse",
+    }
+
+
+def test_progress_event_includes_optional_message_and_metadata() -> None:
+    """Optional progress details are included only when supplied."""
+    event = ProgressEvent(
+        job_id="job-123",
+        status="processing",
+        progress=42,
+        step="parse",
+        message="completed",
+        metadata={"page_count": 2},
+    )
+
+    assert json.loads(event.to_json()) == {
+        "job_id": "job-123",
+        "status": "processing",
+        "progress": 42,
+        "step": "parse",
+        "message": "completed",
+        "metadata": {"page_count": 2},
+    }
+
+
+def test_redis_progress_publisher_publishes_to_job_channel() -> None:
+    """RedisProgressPublisher emits JSON progress events to job:{job_id}."""
+    redis_client = FakeRedisClient()
+    publisher = RedisProgressPublisher(redis_client=redis_client)
+
+    publisher.publish(
+        job_id="job-123",
+        status="processing",
+        progress=20,
+        step="PDF Parsing",
+    )
+
+    assert len(redis_client.messages) == 1
+    channel, message = redis_client.messages[0]
+    assert channel == "job:job-123"
+    assert json.loads(message) == {
+        "job_id": "job-123",
+        "status": "processing",
+        "progress": 20,
+        "step": "PDF Parsing",
+    }
+
+
+def test_redis_progress_publisher_clamps_progress_range() -> None:
+    """Published progress is clamped to the API's 0-100 contract."""
+    redis_client = FakeRedisClient()
+    publisher = RedisProgressPublisher(redis_client=redis_client)
+
+    publisher.publish(job_id="job-123", status="processing", progress=150, step="parse")
+    publisher.publish(job_id="job-123", status="processing", progress=-10, step="parse")
+
+    assert json.loads(redis_client.messages[0][1])["progress"] == 100
+    assert json.loads(redis_client.messages[1][1])["progress"] == 0

--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -1,12 +1,29 @@
 # Implementation Plan
 
 [Overview]
-Implement fully functional frontend and backend services in the empty `frontend/` and `backend/` directories, covering TODO.md user stories US-002 through US-009.
+Implement fully functional frontend and backend services in the empty `frontend/` and `backend/` directories, covering TODO.md user stories US-002 through US-009. Stage 2 begins with US-012, which adds the pluggable backend pipeline infrastructure required before PDF parsing, preprocessing, segmentation, vectorization, and writer steps can be implemented.
 
 The user's directive is to fill the empty `frontend/` and `backend/` directories with accurate, working code so that both services are fully functional and running. This spans multiple user stories from TODO.md: US-002 (Docker Compose), US-003 (linting), US-005 (FastAPI skeleton), US-006 (PostgreSQL + SQLAlchemy), US-007 (Celery + Redis), US-008 (File Upload API), and US-009 (Next.js 14 landing page with DropZone). The backend will be a FastAPI application with async PostgreSQL, Celery workers, and a file upload endpoint. The frontend will be a Next.js 14 App Router project with TypeScript, TailwindCSS, a drag-and-drop upload zone, and conversion options. A `docker-compose.yml` at the root will orchestrate all 5 services (frontend, backend, worker, postgres, redis). The implementation follows the architecture defined in README.md sections 1-7.
 
 [Types]
 Type system changes span both Python (Pydantic models, SQLAlchemy models, dataclasses) and TypeScript (interfaces mirroring backend schemas).
+
+### Stage 2 Pipeline Types (Python)
+
+```python
+# backend/app/pipeline/context.py
+@dataclass
+class PipelineContext:
+    job_id: str
+    input_path: Path
+    config: dict[str, Any]
+    page_images: list[Path]
+    preprocessed: list[Any]
+    masks: dict[str, Any]
+    primitives: list[Any]
+    output_path: Path | None
+    metadata: dict[str, Any]
+```
 
 ### Backend Types (Python)
 
@@ -105,6 +122,10 @@ File modifications span backend Python package, frontend Next.js project, Docker
 - `backend/app/tasks/__init__.py` — empty package init
 - `backend/app/tasks/celery_app.py` — Celery app instance with Redis broker/backend
 - `backend/app/tasks/placeholder.py` — Dummy Celery task that simulates processing
+- `backend/app/pipeline/context.py` — `PipelineContext` dataclass and progress publisher protocol
+- `backend/app/pipeline/orchestrator.py` — `Pipeline` runner that executes steps in order
+- `backend/app/pipeline/progress.py` — Redis Pub/Sub progress publishing helper
+- `backend/app/pipeline/steps/base.py` — `PipelineStep` abstract base class
 - `backend/alembic.ini` — Alembic configuration pointing to `alembic/` directory
 - `backend/alembic/env.py` — Alembic environment script (async)
 - `backend/alembic/script.py.mako` — migration template


### PR DESCRIPTION
## Summary
- Adds the Stage 2 / Phase 2 pipeline infrastructure for US-012.
- Introduces a pluggable backend pipeline package with:
  - `PipelineContext` dataclass for shared conversion state
  - `PipelineStep` ABC for swappable processing steps
  - `Pipeline.run()` orchestration that executes steps in order
  - Redis Pub/Sub progress publishing via `RedisProgressPublisher`
- Refactors the placeholder Celery progress publisher to use the new shared pipeline progress helper.
- Adds backend unit tests covering ordered execution, context defaults, step progress publishing, Redis event serialization, channel naming, and progress clamping.
- Updates `TODO.md`, `README.md`, and `implementation_plan.md` to reflect US-012 implementation progress.
- Updates the Talisman checksum for the known `TODO.md` false-positive after docs changes.

## Validation
- `pre-commit run --all-files` ✅
- `cd backend && pytest -q` ✅ — 10 passed
- Commit-time pre-commit hooks ✅
- Talisman pre-push scan ✅

Closes #12