### PR TITLE
ci: skip workflow jobs for chore commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@
 # ----------------------------------------------------------------------------
 # Continuous Integration for the AI File Converter.
 # Runs on every push to main and on every pull request.
+# Push commits whose message starts with "chore:" intentionally skip CI jobs.
 #
 # Pipeline:
 #   1. Lint + type-check the backend (ruff, mypy)
@@ -23,6 +24,7 @@ jobs:
   # ---------------------------------------------------------------------------
   backend:
     name: Backend (lint + test)
+    if: ${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore:') }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -61,6 +63,7 @@ jobs:
   # ---------------------------------------------------------------------------
   frontend:
     name: Frontend (lint + build)
+    if: ${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore:') }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -101,6 +104,7 @@ jobs:
   # ---------------------------------------------------------------------------
   docker:
     name: Docker (build validation)
+    if: ${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore:') }}
     runs-on: ubuntu-latest
     needs: [backend, frontend]
     steps:


### PR DESCRIPTION
Implemented and pushed the CI guard change.

## Summary
- Updated `.github/workflows/ci.yml` so CI jobs are skipped on `push` events when the head commit message starts with `chore:`.
- Applied the condition to all 3 workflow jobs:
  - `backend`
  - `frontend`
  - `docker`
- Pull request events are unaffected and will still run CI.

## Validation
- Verified the `startsWith(..., 'chore:')` guard appears 3 times in `ci.yml`.
- `pre-commit run --all-files` ✅
- Commit-time pre-commit hooks ✅
- Talisman pre-push scan ✅
- Branch pushed: `chore/skip-ci-for-chore-commits`
- Confirmed no PR was created: `gh pr list --head chore/skip-ci-for-chore-commits` returned `[]`
