### PR TITLE
Fix/pr agent every pr comments

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,27 +1,28 @@
 name: PR Agent
+
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, synchronize, review_requested, edited]
   issue_comment:
+    types: [created]
+
 jobs:
-  pr_agent_job:
-    if: ${{ github.event.sender.type != 'Bot' }}
+  pr-agent:
+    name: Review, describe, and improve pull requests
+    if: ${{ github.event.sender.type != 'Bot' && (github.event_name == 'pull_request' || github.event.issue.pull_request != null) }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write
-      contents: write
-    name: Run pr agent on every pull request, respond to user comments
+      contents: read
     steps:
-      - name: PR Agent action step
+      - name: Run PR Agent
         id: pr-agent
         uses: the-pr-agent/pr-agent@main
         env:
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
-          GITHUB_TOKEN: ${{ secrets.PROJECT_TOKEN }}
-          # Enable/disable automatic tools
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Automatically comment on every PR with review, description, and improvement feedback.
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "true"
           github_action_config.auto_improve: "true"
-          # Configure which PR events trigger the action
-          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "review_requested"]'

--- a/.talismanrc
+++ b/.talismanrc
@@ -12,5 +12,5 @@ fileignoreconfig:
 - filename: backend/alembic.ini
   checksum: c31c463716e44ae5cdc42f0b6332f601a15acbd071f479b15daee24febb263a3
 - filename: .github/workflows/pr-agent.yml
-  checksum: 69381df8e3b806e82c65ac05c9519736fd01fb53062aa472ca0a71f0bbba82df
+  checksum: 183a0a2a3e32f0b9874f724d0e32d8bdbe4d825227ae9ec624302a9ccf4e3bd0
 version: "1.0"


### PR DESCRIPTION
Implemented and pushed the PR-Agent workflow fix.

## Summary
- Updated `.github/workflows/pr-agent.yml` so PR-Agent runs automatically on PR activity:
  - `opened`
  - `reopened`
  - `ready_for_review`
  - `synchronize` — new commits pushed to a PR
  - `review_requested`
  - `edited`
- Kept `issue_comment` support for created comments, guarded to PR comments only.
- Enabled automatic PR-Agent comment tools:
  - `github_action_config.auto_review: "true"`
  - `github_action_config.auto_describe: "true"`
  - `github_action_config.auto_improve: "true"`
- Set permissions for PR commenting/reviewing, not committing:
  - `issues: write`
  - `pull-requests: write`
  - `contents: read`
- Updated `.talismanrc` for the known `OPENAI_KEY` false-positive in `pr-agent.yml`.

## Validation
- Confirmed branch is pushed: `fix/pr-agent-every-pr-comments`
- Confirmed no PR was created: `gh pr list --head fix/pr-agent-every-pr-comments` returned `[]`
- Verified workflow contains PR triggers, PR-comment guard, auto review/describe/improve settings, and `contents: read`
- Commit-time hooks passed with backend virtualenv on PATH
- Talisman pre-push scan passed
- Worktree is clean

## Commits
- `57ddc6f ci: run PR Agent comments on every pull request`
- `300f86d chore: update Talisman checksum for PR Agent workflow`