### PR TITLE
Feature/us 015 page thumbnails

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -12,5 +12,9 @@ fileignoreconfig:
 - filename: frontend/package-lock.json
   checksum: 420a5bb16709bc984a128ca142ede5b5f2a1ac311d2c465912ab6bf99a39b3b4
 - filename: TODO.md
-  checksum: 05dfca772a10705abbdd91b62efee283906f5255f6331149559be13b8610b014
+  checksum: 249d21b76a057da331ba96ccea582eb8b66e796df04d56c1752f6f4c96b8be4
+- filename: frontend/src/components/job/PageViewer.tsx
+  checksum: 161987d127228af51e82420c88594a54b972c9c7ae6814a36263804cfebc8a31
+- filename: frontend/src/components/job/ImageModal.tsx
+  checksum: c32c61f27917ececc5afe2ff60f61881ab0ec0f4cb11383a1066642f34b0d345
 version: "1.0"

--- a/.talismanrc
+++ b/.talismanrc
@@ -12,7 +12,7 @@ fileignoreconfig:
 - filename: frontend/package-lock.json
   checksum: 420a5bb16709bc984a128ca142ede5b5f2a1ac311d2c465912ab6bf99a39b3b4
 - filename: TODO.md
-  checksum: 249d21b76a057da331ba96ccea582eb8b66e796df04d56c1752f6f4c96b8be4
+  checksum: 4509e98ac1e6a8fa42271539f033e19cfec37cd0b761664b7c6168b7e7cebd9e
 - filename: frontend/src/components/job/PageViewer.tsx
   checksum: 161987d127228af51e82420c88594a54b972c9c7ae6814a36263804cfebc8a31
 - filename: frontend/src/components/job/ImageModal.tsx

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A web application that converts architecture drawings (PDFs) into editable 2D or 3D CAD models in DWG (and DXF) format. Built with a modern, decoupled architecture that separates the user-facing experience (Next.js) from the compute-heavy image processing and ML pipeline (Python/FastAPI).
 
-> **Status:** Implementation in progress — Phase 1 (scaffolding & upload flow) is complete and running, and Phase 2 pipeline infrastructure, PyMuPDF page extraction, and OpenCV preprocessing are in review. All 5 Docker services (frontend, backend, worker, postgres, redis) are operational. See the phased roadmap at the bottom for what's next.
+> **Status:** Implementation in progress — Phase 1 (scaffolding & upload flow) and Phase 2 (PDF parsing, preprocessing, page preview) are complete and in review. All 5 Docker services (frontend, backend, worker, postgres, redis) are operational. See the phased roadmap at the bottom for what's next.
 >
 > 📋 **Looking for the execution plan?** See [TODO.md](./TODO.md) — a complete breakdown of 28 user stories and 92 actionable tasks managed as **GitHub Issues** via the `gh` CLI and the GitHub MCP server.
 
@@ -114,7 +114,9 @@ frontend/src/
 │   │   ├── DropZone.tsx          # Drag & drop (react-dropzone)
 │   │   └── ConversionOptions.tsx # 2D/3D toggle, DPI, floor height, format
 │   ├── job/
-│   │   └── ProgressTracker.tsx   # Stepper: Uploaded → Processing → Completed
+│   │   ├── ProgressTracker.tsx   # Stepper: Uploaded → Processing → Completed
+│   │   ├── PageViewer.tsx        # Horizontal strip of page thumbnails
+│   │   └── ImageModal.tsx        # Click-to-enlarge modal for page preview
 │   └── shared/
 │       ├── Button.tsx
 │       └── Card.tsx
@@ -359,7 +361,7 @@ result = Pipeline([
 - [x] Redis Pub/Sub progress publisher for pipeline steps
 - [x] PyMuPDF integration → extract pages as configurable-DPI PNG images
 - [x] OpenCV preprocessing pipeline (grayscale, Gaussian blur, adaptive threshold, deskew)
-- Page preview in frontend
+- [x] Page preview in frontend (horizontal thumbnail strip with click-to-enlarge modal)
 
 ### Phase 3 — 2D Vectorization (core value)
 - Integrate pre-trained floor plan segmentation model (e.g. fine-tuned on CubiCasa5K)
@@ -596,4 +598,4 @@ See [TODO.md §A](./TODO.md) for the full GitHub issue management playbook, incl
 
 ---
 
-*Document version 0.5 — updated to reflect Phase 1 implementation and Phase 2 pipeline infrastructure, PyMuPDF page extraction, and OpenCV preprocessing.*
+*Document version 0.6 — updated to reflect Phase 2 complete with page preview. Phase 1 and Phase 2 implementations are in review.*

--- a/TODO.md
+++ b/TODO.md
@@ -57,6 +57,7 @@
 | 2026-07-23 | Stage 2 — US-012 | Not opened | US-012 | Pipeline framework, context dataclass, ordered orchestrator, and Redis Pub/Sub progress publisher prepared on `feat/us-012-pipeline-infrastructure`. |
 | 2026-07-23 | Stage 2 — US-013 | Not opened | US-013 | PyMuPDF parser step extracts PDF pages to configurable-DPI PNG images and reports the 20% pipeline milestone on `feat/us-013-pdf-page-extraction`. |
 | 2026-07-23 | Stage 2 — US-014 | Not opened | US-014 | OpenCV preprocessing converts pages to grayscale binary arrays, applies blur and adaptive thresholding, corrects skew, and reports the 35% milestone on `feature/US-014-opencv-preprocessing`. |
+| 2026-07-27 | Stage 2 — US-015 | Not opened | US-015 | Page thumbnail preview: backend endpoint (`GET /jobs/{id}/pages/{n}`), PageViewer horizontal thumbnail strip, and click-to-enlarge modal on the job detail page on `feature/US-015-page-thumbnails`. |
 
 ---
 
@@ -275,16 +276,16 @@
 ## Epic 2.2 — Frontend Preview
 
 ### US-015 · As a user, I want to see extracted page thumbnails on the job page
-- **Priority:** P1 · **Effort:** S · **Status:** ⬜ Backlog · **Labels:** `area:frontend`, `epic:p2-pdf`
+- **Priority:** P1 · **Effort:** S · **Status:** 👀 In Review · **Labels:** `area:frontend`, `epic:p2-pdf`
 - **Acceptance Criteria:**
-  - [ ] `/jobs/{id}/pages/{n}` endpoint serves extracted page images
-  - [ ] Job detail page shows a horizontal strip of page thumbnails
-  - [ ] Click thumbnail to enlarge in modal
+  - [x] `/jobs/{id}/pages/{n}` endpoint serves extracted page images
+  - [x] Job detail page shows a horizontal strip of page thumbnails
+  - [x] Click thumbnail to enlarge in modal
 - **Tasks:**
-  - [ ] T-048 — Add `GET /api/v1/jobs/{id}/pages/{n}` endpoint
-  - [ ] T-049 — Create `components/job/PageViewer.tsx`
-  - [ ] T-050 — Integrate `PageViewer` into `app/jobs/[id]/page.tsx`
-  - [ ] T-051 — Add image modal component
+  - [x] T-048 — Add `GET /api/v1/jobs/{id}/pages/{n}` endpoint
+  - [x] T-049 — Create `components/job/PageViewer.tsx`
+  - [x] T-050 — Integrate `PageViewer` into `app/jobs/[id]/page.tsx`
+  - [x] T-051 — Add image modal component
 
 ---
 
@@ -739,4 +740,4 @@ Stage 5 (Polish)                      ▼
 
 ---
 
-*Document version 0.5 — updated 2026-07-23 to reflect Phase 1 implementation and US-012 → US-014 pipeline progress. US-001 ✅ Done; US-002 → US-014 👀 In Review.*
+*Document version 0.6 — updated 2026-07-27 to reflect US-015 page thumbnail preview. US-001 ✅ Done; US-002 → US-015 👀 In Review.*

--- a/backend/app/api/v1/jobs_pages.py
+++ b/backend/app/api/v1/jobs_pages.py
@@ -50,10 +50,19 @@ async def get_job_page(
             detail=f"Job {job_id} not found",
         )
 
-    # Construct the expected page image path
+    # Construct and validate the expected page image path
     # PdfParserStep stores pages at: {storage_path}/{job_id}/pages/page_{n:04d}.png
-    storage_base = Path(settings.STORAGE_PATH)
-    page_image = storage_base / job_id / "pages" / f"page_{page_number:04d}.png"
+    storage_base = Path(settings.STORAGE_PATH).resolve()
+    job_pages_dir = (storage_base / job_id / "pages").resolve()
+    page_image = (job_pages_dir / f"page_{page_number:04d}.png").resolve()
+
+    try:
+        page_image.relative_to(job_pages_dir)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid page path",
+        )
 
     if not page_image.exists():
         raise HTTPException(

--- a/backend/app/api/v1/jobs_pages.py
+++ b/backend/app/api/v1/jobs_pages.py
@@ -1,6 +1,7 @@
 """Endpoint for serving extracted page images."""
 
 from pathlib import Path
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import FileResponse
@@ -17,7 +18,7 @@ settings = get_settings()
 
 @router.get("/jobs/{job_id}/pages/{page_number}")
 async def get_job_page(
-    job_id: str,
+    job_id: UUID,
     page_number: int,
     db: AsyncSession = Depends(get_db),
 ) -> FileResponse:
@@ -41,19 +42,29 @@ async def get_job_page(
             detail="Page number must be 1 or greater",
         )
 
-    result = await db.execute(select(Job).where(Job.id == job_id))
+    job_id_str = str(job_id)
+    result = await db.execute(select(Job).where(Job.id == job_id_str))
     job = result.scalar_one_or_none()
 
     if not job:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Job {job_id} not found",
+            detail=f"Job {job_id_str} not found",
         )
 
     # Construct and validate the expected page image path
     # PdfParserStep stores pages at: {storage_path}/{job_id}/pages/page_{n:04d}.png
     storage_base = Path(settings.STORAGE_PATH).resolve()
-    job_pages_dir = (storage_base / job_id / "pages").resolve()
+    job_pages_dir = (storage_base / job_id_str / "pages").resolve()
+
+    try:
+        job_pages_dir.relative_to(storage_base)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid job path",
+        )
+
     page_image = (job_pages_dir / f"page_{page_number:04d}.png").resolve()
 
     try:

--- a/backend/app/api/v1/jobs_pages.py
+++ b/backend/app/api/v1/jobs_pages.py
@@ -55,10 +55,20 @@ async def get_job_page(
     # Construct and validate the expected page image path
     # PdfParserStep stores pages at: {storage_path}/{job_id}/pages/page_{n:04d}.png
     storage_base = Path(settings.STORAGE_PATH).resolve()
-    job_pages_dir = (storage_base / job_id_str / "pages").resolve()
+    job_storage_dir = Path(job.storage_path).resolve()
 
     try:
-        job_pages_dir.relative_to(storage_base)
+        job_storage_dir.relative_to(storage_base)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid job path",
+        )
+
+    job_pages_dir = (job_storage_dir / "pages").resolve()
+
+    try:
+        job_pages_dir.relative_to(job_storage_dir)
     except ValueError:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/api/v1/jobs_pages.py
+++ b/backend/app/api/v1/jobs_pages.py
@@ -1,0 +1,68 @@
+"""Endpoint for serving extracted page images."""
+
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import FileResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import get_settings
+from app.core.database import get_db
+from app.models.job import Job
+
+router = APIRouter()
+settings = get_settings()
+
+
+@router.get("/jobs/{job_id}/pages/{page_number}")
+async def get_job_page(
+    job_id: str,
+    page_number: int,
+    db: AsyncSession = Depends(get_db),
+) -> FileResponse:
+    """Serve an extracted page image for a given job and page number.
+
+    Args:
+        job_id: The job UUID as a string.
+        page_number: The 1-based page number.
+        db: Database session.
+
+    Returns:
+        FileResponse with the page image.
+
+    Raises:
+        HTTPException 404: If the job or page image is not found.
+        HTTPException 400: If the page number is invalid.
+    """
+    if page_number < 1:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Page number must be 1 or greater",
+        )
+
+    result = await db.execute(select(Job).where(Job.id == job_id))
+    job = result.scalar_one_or_none()
+
+    if not job:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Job {job_id} not found",
+        )
+
+    # Construct the expected page image path
+    # PdfParserStep stores pages at: {storage_path}/{job_id}/pages/page_{n:04d}.png
+    storage_base = Path(settings.STORAGE_PATH)
+    page_image = storage_base / job_id / "pages" / f"page_{page_number:04d}.png"
+
+    if not page_image.exists():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Page {page_number} not found for job {job_id}",
+        )
+
+    return FileResponse(
+        path=str(page_image),
+        media_type="image/png",
+        filename=f"page_{page_number:04d}.png",
+    )

--- a/backend/app/api/v1/jobs_pages.py
+++ b/backend/app/api/v1/jobs_pages.py
@@ -52,10 +52,10 @@ async def get_job_page(
             detail=f"Job {job_id_str} not found",
         )
 
-    # Construct and validate the expected page image path
+    # Construct and validate the expected page image path from safe components.
     # PdfParserStep stores pages at: {storage_path}/{job_id}/pages/page_{n:04d}.png
     storage_base = Path(settings.STORAGE_PATH).resolve()
-    job_storage_dir = Path(job.storage_path).resolve()
+    job_storage_dir = (storage_base / job_id_str).resolve()
 
     try:
         job_storage_dir.relative_to(storage_base)

--- a/backend/app/api/v1/jobs_pages.py
+++ b/backend/app/api/v1/jobs_pages.py
@@ -1,5 +1,6 @@
 """Endpoint for serving extracted page images."""
 
+import re
 from pathlib import Path
 from uuid import UUID
 
@@ -14,6 +15,42 @@ from app.models.job import Job
 
 router = APIRouter()
 settings = get_settings()
+
+_PAGE_IMAGE_PATTERN = re.compile(r"^page_(\d{4})\.png$")
+
+
+def _ensure_child_path(path: Path, parent: Path, detail: str) -> None:
+    """Ensure a resolved path remains inside its expected resolved parent."""
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=detail,
+        ) from None
+
+
+def _find_page_image(job_pages_dir: Path, page_number: int) -> Path | None:
+    """Return a page image selected from trusted storage using an allowlisted name."""
+    if not job_pages_dir.is_dir():
+        return None
+
+    for candidate in job_pages_dir.iterdir():
+        match = _PAGE_IMAGE_PATTERN.fullmatch(candidate.name)
+        if match is None or int(match.group(1)) != page_number:
+            continue
+
+        resolved_candidate = candidate.resolve()
+        _ensure_child_path(
+            resolved_candidate,
+            job_pages_dir,
+            "Invalid page path",
+        )
+
+        if resolved_candidate.is_file():
+            return resolved_candidate
+
+    return None
 
 
 @router.get("/jobs/{job_id}/pages/{page_number}")
@@ -42,50 +79,35 @@ async def get_job_page(
             detail="Page number must be 1 or greater",
         )
 
-    job_id_str = str(job_id)
-    result = await db.execute(select(Job).where(Job.id == job_id_str))
+    result = await db.execute(select(Job).where(Job.id == job_id))
     job = result.scalar_one_or_none()
 
     if not job:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Job {job_id_str} not found",
+            detail=f"Job {job_id} not found",
         )
 
-    # Construct and validate the expected page image path from safe components.
+    if job.page_count is not None and page_number > job.page_count:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Page {page_number} not found for job {job_id}",
+        )
+
+    # Construct job storage paths only from configured storage and persisted job data.
     # PdfParserStep stores pages at: {storage_path}/{job_id}/pages/page_{n:04d}.png
     storage_base = Path(settings.STORAGE_PATH).resolve()
-    job_storage_dir = (storage_base / job_id_str).resolve()
+    persisted_job_dir_name = str(job.id)
+    job_storage_dir = (storage_base / persisted_job_dir_name).resolve()
 
-    try:
-        job_storage_dir.relative_to(storage_base)
-    except ValueError:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid job path",
-        )
+    _ensure_child_path(job_storage_dir, storage_base, "Invalid job path")
 
     job_pages_dir = (job_storage_dir / "pages").resolve()
 
-    try:
-        job_pages_dir.relative_to(job_storage_dir)
-    except ValueError:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid job path",
-        )
+    _ensure_child_path(job_pages_dir, job_storage_dir, "Invalid job path")
 
-    page_image = (job_pages_dir / f"page_{page_number:04d}.png").resolve()
-
-    try:
-        page_image.relative_to(job_pages_dir)
-    except ValueError:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid page path",
-        )
-
-    if not page_image.exists():
+    page_image = _find_page_image(job_pages_dir, page_number)
+    if page_image is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Page {page_number} not found for job {job_id}",
@@ -94,5 +116,5 @@ async def get_job_page(
     return FileResponse(
         path=str(page_image),
         media_type="image/png",
-        filename=f"page_{page_number:04d}.png",
+        filename=page_image.name,
     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.v1.health import router as health_router
 from app.api.v1.jobs import router as jobs_router
+from app.api.v1.jobs_pages import router as jobs_pages_router
 from app.api.v1.jobs_stream import router as jobs_stream_router
 from app.core.config import get_settings
 
@@ -42,6 +43,7 @@ def create_app() -> FastAPI:
     api_prefix = settings.API_V1_PREFIX
     app.include_router(health_router, prefix=api_prefix, tags=["health"])
     app.include_router(jobs_router, prefix=api_prefix, tags=["jobs"])
+    app.include_router(jobs_pages_router, prefix=api_prefix, tags=["jobs"])
     app.include_router(jobs_stream_router, prefix=api_prefix, tags=["jobs"])
 
     return app

--- a/frontend/src/app/jobs/[id]/page.tsx
+++ b/frontend/src/app/jobs/[id]/page.tsx
@@ -1,16 +1,28 @@
 "use client";
 
-import { use } from "react";
+import { use, useEffect, useState } from "react";
 import Link from "next/link";
 import Card from "@/components/shared/Card";
 import Button from "@/components/shared/Button";
 import ProgressTracker from "@/components/job/ProgressTracker";
+import PageViewer from "@/components/job/PageViewer";
+import { getJob } from "@/lib/api";
+import type { Job } from "@/types/api";
 
 export default function JobDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
+  const [job, setJob] = useState<Job | null>(null);
+
+  useEffect(() => {
+    getJob(id)
+      .then(setJob)
+      .catch(() => {
+        /* error handled by ProgressTracker SSE */
+      });
+  }, [id]);
 
   return (
-    <div className="mx-auto max-w-2xl px-4 py-12">
+    <div className="mx-auto max-w-4xl px-4 py-12">
       <div className="mb-6">
         <Link href="/" className="text-sm text-primary hover:underline">
           ← Back to upload
@@ -19,6 +31,11 @@ export default function JobDetailPage({ params }: { params: Promise<{ id: string
 
       <Card title={`Job ${id}`}>
         <ProgressTracker jobId={id} />
+        {job && job.page_count && job.page_count > 0 && (
+          <div className="mt-6">
+            <PageViewer jobId={id} pageCount={job.page_count} />
+          </div>
+        )}
         <div className="mt-6">
           <a href={`${process.env.NEXT_PUBLIC_API_URL || ""}/api/v1/jobs/${id}/download`}>
             <Button variant="outline" className="w-full">

--- a/frontend/src/components/job/ImageModal.tsx
+++ b/frontend/src/components/job/ImageModal.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useCallback } from "react";
+
+interface ImageModalProps {
+  src: string;
+  alt: string;
+  onClose: () => void;
+}
+
+export default function ImageModal({ src, alt, onClose }: ImageModalProps) {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [handleKeyDown]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Enlarged page image"
+    >
+      <button
+        onClick={onClose}
+        className="absolute right-4 top-4 rounded-full bg-white/20 p-2 text-white transition-colors hover:bg-white/40"
+        aria-label="Close modal"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-6 w-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M6 18L18 6M6 6l12 12"
+          />
+        </svg>
+      </button>
+      <img
+        src={src}
+        alt={alt}
+        className="max-h-[90vh] max-w-[90vw] rounded-lg object-contain shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/job/PageViewer.tsx
+++ b/frontend/src/components/job/PageViewer.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+import ImageModal from "./ImageModal";
+import { getPageImageUrl } from "@/lib/api";
+
+interface PageViewerProps {
+  jobId: string;
+  pageCount: number;
+}
+
+export default function PageViewer({ jobId, pageCount }: PageViewerProps) {
+  const [selectedPage, setSelectedPage] = useState<number | null>(null);
+
+  if (pageCount === 0) {
+    return null;
+  }
+
+  return (
+    <div>
+      <h3 className="mb-3 text-lg font-semibold text-gray-900">Page Preview</h3>
+      <div className="flex gap-3 overflow-x-auto pb-2">
+        {Array.from({ length: pageCount }, (_, i) => i + 1).map((pageNum) => (
+          <button
+            key={pageNum}
+            onClick={() => setSelectedPage(pageNum)}
+            className="flex-shrink-0 overflow-hidden rounded-lg border border-gray-200 transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-primary"
+            aria-label={`View page ${pageNum}`}
+          >
+            <img
+              src={getPageImageUrl(jobId, pageNum)}
+              alt={`Page ${pageNum}`}
+              className="h-40 w-28 object-cover"
+              loading="lazy"
+            />
+            <div className="border-t border-gray-100 bg-gray-50 px-2 py-1 text-center text-xs text-gray-500">
+              Page {pageNum}
+            </div>
+          </button>
+        ))}
+      </div>
+
+      {selectedPage !== null && (
+        <ImageModal
+          src={getPageImageUrl(jobId, selectedPage)}
+          alt={`Page ${selectedPage}`}
+          onClose={() => setSelectedPage(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -28,6 +28,10 @@ export async function uploadFile(
   return response.json();
 }
 
+export function getPageImageUrl(jobId: string, pageNumber: number): string {
+  return `${API_BASE}/api/v1/jobs/${jobId}/pages/${pageNumber}`;
+}
+
 export async function getJob(jobId: string): Promise<Job> {
   const response = await fetch(`${API_BASE}/api/v1/jobs/${jobId}`);
   if (!response.ok) {


### PR DESCRIPTION
US-015 has been fully implemented on the `feature/US-015-page-thumbnails` branch and pushed to GitHub. No PR was created.

**5 commits (split into logical chunks):**
1. `94e813f` — feat(api): add GET /api/v1/jobs/{id}/pages/{n} endpoint (T-048)
2. `8b40334` — feat(ui): add PageViewer and ImageModal components (T-049, T-051)
3. `3f2bb79` — feat(ui): integrate PageViewer into job detail page (T-050)
4. `46fe8b4` — docs: mark US-015 in review, update TODO.md and README.md
5. `510ebfe` — chore: update talisman checksum for new/updated files

**Acceptance criteria met:**
- ✅ `GET /api/v1/jobs/{id}/pages/{n}` endpoint serves extracted page images
- ✅ Job detail page shows horizontal strip of page thumbnails
- ✅ Click thumbnail to enlarge in modal

closes #15 