### PR TITLE
Feature/stage 4 3d extrusion

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -10,15 +10,15 @@ fileignoreconfig:
 - filename: .github/workflows/pr-agent.yml
   checksum: 029fbcf2e43a8b51d187cc9f29a8eeb3de4504a14d5b9c1120072cf950f00d33
 - filename: frontend/package-lock.json
-  checksum: 420a5bb16709bc984a128ca142ede5b5f2a1ac311d2c465912ab6bf99a39b3b4
+  checksum: e2d4b634d51975aea55e32f43c51b61c1d5621a9756959b6258ebb955b7e6f2b
 - filename: TODO.md
-  checksum: ffdf34f37e1ae38fff5ac82933f2da7f91d00b7716cddf3282b3a9993e1f3e20
+  checksum: d1783877818cbb8e282f8b1b212311bad3cbc4f68e59c120fe0afb74d0db289a
 - filename: frontend/src/components/job/PageViewer.tsx
   checksum: 161987d127228af51e82420c88594a54b972c9c7ae6814a36263804cfebc8a31
 - filename: frontend/src/components/job/ImageModal.tsx
   checksum: c32c61f27917ececc5afe2ff60f61881ab0ec0f4cb11383a1066642f34b0d345
 - filename: backend/tests/test_jobs_download.py
-  checksum: bb74a51e99ef29c4123bf6cc8bd273488714ccea3becb1e5570086c31a732576
+  checksum: dd990c0ba5b2711a575a1d6c2932243e2269a92c0044d0a2b78616e4bed10789
 - filename: backend/app/pipeline/steps/vectorizer.py
   checksum: 69a216446d5421c4a5c27f461f6c341934e4cb05a2d0373f11e98f87bed9511f
 version: "1.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A web application that converts architecture drawings (PDFs) into editable 2D or 3D CAD models in DWG (and DXF) format. Built with a modern, decoupled architecture that separates the user-facing experience (Next.js) from the compute-heavy image processing and ML pipeline (Python/FastAPI).
 
-> **Status:** Implementation in progress — Phase 1 (scaffolding & upload flow), Phase 2 (PDF parsing, preprocessing, page preview), and Phase 3 2D vectorization/DXF export are complete and in review. All 5 Docker services (frontend, backend, worker, postgres, redis) are operational. See the phased roadmap at the bottom for what's next.
+> **Status:** Implementation in progress — Phase 1 (scaffolding & upload flow), Phase 2 (PDF parsing, preprocessing, page preview), Phase 3 2D vectorization/DXF export, and Phase 4 3D extrusion (wall/slab solids, 3D DXF + GLB export, in-browser 3D preview) are complete and in review. All 5 Docker services (frontend, backend, worker, postgres, redis) are operational. See the phased roadmap at the bottom for what's next.
 >
 > 📋 **Looking for the execution plan?** See [TODO.md](./TODO.md) — a complete breakdown of 28 user stories and 92 actionable tasks managed as **GitHub Issues** via the `gh` CLI and the GitHub MCP server.
 
@@ -72,14 +72,19 @@ The pipeline runs inside the Celery worker and is composed of pluggable steps. E
                       walls, doors, windows, rooms, text regions
        │
        ▼
-[5] 3D Extrusion      (if 3D mode) Extrude walls by floor height metadata
-   [optional]         or user-specified height. Add slabs and openings.
+[5] 3D Extrusion      (if 3D mode) Extrude walls into rectangular prisms by the
+   [optional]         configured floor height, add floor/ceiling slabs. Reports 85%.
        │
        ▼
-[6] DXF Writer        Write primitives to layered DXF with ezdxf
+[6] DXF Writer        Write primitives to layered DXF with ezdxf (2D layers plus
+                      3D `WALLS_3D` / `SLABS` 3DFACE geometry). Reports 95%.
        │
        ▼
-  Output File
+[7] GLB Writer        (if 3D mode) Export a self-contained GLB (binary glTF) mesh
+   [optional]         with trimesh for browser preview and download. Reports 97%.
+       │
+       ▼
+  Output File(s)
 ```
 
 ### Reference: Pipeline Context
@@ -147,7 +152,7 @@ frontend/src/
 | `GET` | `/api/v1/jobs/{id}` | Get job status, progress (0–100), current step |
 | `GET` | `/api/v1/jobs/{id}/stream` | **SSE** — real-time progress updates |
 | `GET` | `/api/v1/jobs/{id}/pages/{n}` | Extracted page image (for preview) |
-| `GET` | `/api/v1/jobs/{id}/download` | Download generated DXF with attachment Content-Disposition |
+| `GET` | `/api/v1/jobs/{id}/download` | Download generated DXF (default) or GLB via `?format=dxf\|glb` with attachment Content-Disposition |
 | `GET` | `/api/v1/jobs` | List all jobs (paginated, filterable by status) |
 | `DELETE` | `/api/v1/jobs/{id}` | Delete job + associated files |
 | `GET` | `/api/v1/health` | Health check (liveness/readiness) |
@@ -282,7 +287,9 @@ Implemented foundation:
 - `backend/app/pipeline/steps/segmenter.py` implements ONNX Runtime semantic segmentation plus a Classic CV fallback.
 - `backend/app/pipeline/primitives.py` defines typed CAD primitives (`WallPrimitive`, `OpeningPrimitive`, `RoomPrimitive`, `TextPrimitive`).
 - `backend/app/pipeline/steps/vectorizer.py` converts masks into simplified CAD primitives and reports the 80% milestone.
-- `backend/app/pipeline/steps/dxf_writer.py` writes `WALLS`, `DOORS`, `WINDOWS`, `ROOMS`, and `TEXT` layers to DXF and reports the 95% milestone.
+- `backend/app/pipeline/steps/dxf_writer.py` writes `WALLS`, `DOORS`, `WINDOWS`, `ROOMS`, and `TEXT` layers to DXF (plus `WALLS_3D` / `SLABS` 3DFACE geometry for 3D jobs) and reports the 95% milestone.
+- `backend/app/pipeline/steps/extruder.py` (`WallExtruderStep`) extrudes walls into 3D prisms and adds floor/ceiling slabs, reporting the 85% milestone.
+- `backend/app/pipeline/steps/glb_writer.py` (`GlbWriterStep`) exports a self-contained GLB (binary glTF) via `trimesh` for 3D jobs.
 - `backend/app/pipeline/orchestrator.py` provides `Pipeline.run()` for ordered step execution.
 - `backend/app/pipeline/progress.py` provides Redis Pub/Sub progress publishing.
 
@@ -370,9 +377,12 @@ result = Pipeline([
 - [x] Downloadable DXF output appears when jobs complete
 
 ### Phase 4 — 3D Extrusion
-- Extrude walls by configurable height
-- Add floor slabs and door/window openings
-- Export as 3D DXF (and optionally IFC)
+- [x] Extrude walls into rectangular prisms by configurable floor height (default 3.0m)
+- [x] Add floor slabs (and optional ceiling slab) from detected room polygons
+- [x] Export 3D DXF (`3DFACE` / `POLYLINE 3D` on `WALLS_3D` / `SLABS` layers)
+- [x] Export a self-contained GLB (binary glTF) via `trimesh`
+- [x] In-browser 3D preview (`three` / `@react-three/fiber`) with orbit controls and wireframe/solid toggle
+- [x] `?format=glb` download endpoint for the 3D model
 
 ### Phase 5 — Polish & DWG Export
 - DWG conversion via `libredwg` or ODA `FileConverter`
@@ -398,6 +408,9 @@ redis==5.*               # Celery broker + Pub/Sub
 pymupdf==1.*             # PDF page rendering
 onnxruntime==1.*         # CPU ML segmentation inference
 ezdxf==1.*              # DXF generation and validation
+trimesh==4.*            # 3D mesh construction + GLB (binary glTF) export
+shapely==2.*            # polygon geometry for slab/wall extrusion
+manifold3d==3.*         # robust mesh boolean/extrusion backend for trimesh
 sse-starlette==2.*       # SSE streaming
 ruff==0.8.*              # linting
 mypy==1.*                # type checking
@@ -425,7 +438,10 @@ numpy==2.*
     "tailwindcss": "^3.4.0",
     "react-dropzone": "^14.2.0",
     "sonner": "^1.4.0",
-    "zod": "^3.23.0"
+    "zod": "^3.23.0",
+    "three": "^0.169.0",
+    "@react-three/fiber": "^8.17.0",
+    "@react-three/drei": "^9.114.0"
   }
 }
 ```
@@ -599,4 +615,4 @@ See [TODO.md §A](./TODO.md) for the full GitHub issue management playbook, incl
 
 ---
 
-*Document version 0.8 — updated to reflect Epic 3.2/3.3 vectorization, DXF generation, and completed-job downloads. Phase 1, Phase 2, and Phase 3 implementations are in review.*
+*Document version 0.9 — updated to reflect Phase 4 3D extrusion: wall/slab solids, 3D DXF + GLB export, `?format=glb` download, and the in-browser Three.js 3D preview. Phases 1–4 implementations are in review.*

--- a/TODO.md
+++ b/TODO.md
@@ -41,7 +41,7 @@
 | 1 | **Phase 1 — MVP Skeleton** | Upload + queue + job tracking | 👀 In Review | 5 | 18 |
 | 2 | **Phase 2 — PDF Parsing** | Extract & preview page images | 🚧 In Progress | 4 | 14 |
 | 3 | **Phase 3 — 2D Vectorization** | PDF → DXF (core value) | 👀 In Review | 5 | 16 |
-| 4 | **Phase 4 — 3D Extrusion** | Walls → 3D model | ⬜ Backlog | 4 | 12 |
+| 4 | **Phase 4 — 3D Extrusion** | Walls → 3D model | 👀 In Review | 4 | 12 |
 | 5 | **Phase 5 — Polish & DWG** | Production-ready with DWG export | ⬜ Backlog | 6 | 20 |
 
 **Total: 28 user stories · 92 actionable tasks**
@@ -60,6 +60,7 @@
 | 2026-07-27 | Stage 2 — US-015 | Not opened | US-015 | Page thumbnail preview: backend endpoint (`GET /jobs/{id}/pages/{n}`), PageViewer horizontal thumbnail strip, and click-to-enlarge modal on the job detail page on `feature/US-015-page-thumbnails`. |
 | 2026-07-27 | Stage 3 — Epic 3.1 | Not opened | US-016 → US-017 | Semantic segmentation step with CPU ONNX Runtime backend, cached model loading, persisted per-label masks, and Classic CV fallback selectable via job config on `feature/epic-3-1-semantic-segmentation`. |
 | 2026-07-27 | Stage 3 — Epic 3.2/3.3 | Not opened | US-018 → US-020 | Semantic masks now vectorize into CAD primitives, write readable layered DXF files with `ezdxf`, run through the real Celery pipeline, and expose completed-job DXF downloads on `feature/epic-3-vectorization-dxf`. |
+| 2026-07-27 | Stage 4 — Epic 4.1/4.2 | Not opened | US-021 → US-024 | 3D extrusion lifts walls into rectangular prisms with floor/ceiling slabs, writes 3D DXF (`3DFACE`/`POLYLINE 3D`) plus a self-contained GLB via `trimesh`, adds a `three`/`@react-three/fiber` browser preview with orbit controls and wireframe/solid toggle, and serves `?format=glb` downloads on `feature/stage-4-3d-extrusion`. |
 
 ---
 
@@ -368,52 +369,56 @@
 ## Epic 4.1 — Wall Extrusion
 
 ### US-021 · As a backend dev, I want to extrude wall segments into 3D volumes
-- **Priority:** P0 · **Effort:** M · **Status:** ⬜ Backlog · **Labels:** `area:backend`, `epic:p4-3d`
+- **Priority:** P0 · **Effort:** M · **Status:** 👀 In Review · **Labels:** `area:backend`, `epic:p4-3d`
 - **Acceptance Criteria:**
-  - [ ] Each wall becomes a rectangular prism with floor-height as Z-dimension
-  - [ ] Walls respect their original `(start, end, thickness)` geometry
-  - [ ] Configurable floor height (default 3.0m)
-  - [ ] Reports `progress = 85%`
+  - [x] Each wall becomes a rectangular prism with floor-height as Z-dimension
+  - [x] Walls respect their original `(start, end, thickness)` geometry
+  - [x] Configurable floor height (default 3.0m)
+  - [x] Reports `progress = 85%`
 - **Tasks:**
-  - [ ] T-068 — Implement `WallExtruderStep` in `backend/app/pipeline/steps/extruder.py`
-  - [ ] T-069 — Update `Primitive` dataclass to support 3D (3D point + extrusion)
-  - [ ] T-070 — Add 3D primitives to DXF writer (use POLYLINE 3D / 3DFACE)
+  - [x] T-068 — Implement `WallExtruderStep` in `backend/app/pipeline/steps/extruder.py`
+  - [x] T-069 — Update `Primitive` dataclass to support 3D (`Point3D`, `WallSolidPrimitive`, `SlabPrimitive`)
+  - [x] T-070 — Add 3D primitives to DXF writer (`3DFACE` + `POLYLINE 3D` on `WALLS_3D` / `SLABS` layers)
 
 ### US-022 · As a backend dev, I want to add floor and ceiling slabs
-- **Priority:** P1 · **Effort:** M · **Status:** ⬜ Backlog · **Labels:** `area:backend`, `epic:p4-3d`
+- **Priority:** P1 · **Effort:** M · **Status:** 👀 In Review · **Labels:** `area:backend`, `epic:p4-3d`
 - **Acceptance Criteria:**
-  - [ ] Detect room polygons from segmentation
-  - [ ] Add a slab at z=0 covering the union of rooms
-  - [ ] Optional ceiling at z=floor_height
+  - [x] Detect room polygons from segmentation
+  - [x] Add a slab at z=0 covering the union of rooms
+  - [x] Optional ceiling at z=floor_height
 - **Tasks:**
-  - [ ] T-071 — Implement `SlabGenerator` helper in `primitives.py`
-  - [ ] T-072 — Hook slab generation into `WallExtruderStep`
-  - [ ] T-073 — Add slab thickness config (default 0.2m)
+  - [x] T-071 — Implement `SlabGenerator` helper in `primitives.py`
+  - [x] T-072 — Hook slab generation into `WallExtruderStep`
+  - [x] T-073 — Add slab thickness config (default 0.2m)
 
 ## Epic 4.2 — 3D Preview & Export
 
 ### US-023 · As a user, I want to see a 3D preview of the generated model in the browser
-- **Priority:** P2 · **Effort:** M · **Status:** ⬜ Backlog · **Labels:** `area:frontend`, `epic:p4-3d`
+- **Priority:** P2 · **Effort:** M · **Status:** 👀 In Review · **Labels:** `area:frontend`, `epic:p4-3d`
 - **Acceptance Criteria:**
-  - [ ] Job detail page renders a 3D scene when job mode is `3d`
-  - [ ] Orbit controls (zoom, pan, rotate)
-  - [ ] Toggle between wireframe and solid shading
+  - [x] Job detail page renders a 3D scene when job mode is `3d`
+  - [x] Orbit controls (zoom, pan, rotate)
+  - [x] Toggle between wireframe and solid shading
 - **Tasks:**
-  - [ ] T-074 — Add `three` and `@react-three/fiber` to frontend deps
-  - [ ] T-075 — Create `components/job/Model3DPreview.tsx`
-  - [ ] T-076 — Parse DXF into Three.js geometry in the browser
-  - [ ] T-077 — Add view-mode toggle in `ConversionOptions`
+  - [x] T-074 — Add `three`, `@react-three/fiber`, and `@react-three/drei` to frontend deps
+  - [x] T-075 — Create `components/job/Model3DPreview.tsx`
+  - [x] T-076 — Load the exported GLB into Three.js geometry in the browser (via `useGLTF`)
+  - [x] T-077 — Add 3D view/slab options in `ConversionOptions` and a wireframe/solid toggle in the preview
+
+> **Note:** T-076 loads the backend-generated GLB with `@react-three/drei`'s `useGLTF`
+> instead of parsing DXF in the browser — this reuses the same self-contained model
+> produced for US-024 and avoids shipping a DXF parser to the client.
 
 ### US-024 · As a user, I want to download the 3D model in a standard format
-- **Priority:** P2 · **Effort:** M · **Status:** ⬜ Backlog · **Labels:** `area:backend`, `epic:p4-3d`
+- **Priority:** P2 · **Effort:** M · **Status:** 👀 In Review · **Labels:** `area:backend`, `epic:p4-3d`
 - **Acceptance Criteria:**
-  - [ ] In addition to DXF, export to GLB (binary glTF)
-  - [ ] GLB is a single self-contained file
-  - [ ] Opens in any 3D viewer (Blender, online viewers)
+  - [x] In addition to DXF, export to GLB (binary glTF)
+  - [x] GLB is a single self-contained file
+  - [x] Opens in any 3D viewer (Blender, online viewers)
 - **Tasks:**
-  - [ ] T-078 — Add `pygltflib` or `trimesh` to requirements
-  - [ ] T-079 — Implement `GlbWriterStep` in `backend/app/pipeline/steps/glb_writer.py`
-  - [ ] T-080 — Update download endpoint to return `output.glb` when format=glb
+  - [x] T-078 — Add `trimesh` (with `shapely` + `manifold3d`) to requirements
+  - [x] T-079 — Implement `GlbWriterStep` in `backend/app/pipeline/steps/glb_writer.py`
+  - [x] T-080 — Update download endpoint to return `output.glb` when `format=glb`
 
 ---
 
@@ -742,4 +747,4 @@ Stage 5 (Polish)                      ▼
 
 ---
 
-*Document version 0.7 — updated 2026-07-27 to reflect Epic 3.1 semantic segmentation. US-001 ✅ Done; US-002 → US-017 👀 In Review.*
+*Document version 0.8 — updated 2026-07-27 to reflect Stage 4 3D extrusion (Epics 4.1/4.2). US-001 ✅ Done; US-002 → US-024 👀 In Review.*

--- a/backend/app/api/v1/jobs.py
+++ b/backend/app/api/v1/jobs.py
@@ -2,10 +2,10 @@
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
 from fastapi.responses import FileResponse
 from pydantic import ValidationError
 from sqlalchemy import func, select
@@ -115,12 +115,19 @@ async def get_job(
     return JobStatus.model_validate(job)
 
 
+DOWNLOAD_FORMATS: dict[str, dict[str, str]] = {
+    "dxf": {"suffix": ".dxf", "filename": "output.dxf", "media_type": "application/dxf"},
+    "glb": {"suffix": ".glb", "filename": "output.glb", "media_type": "model/gltf-binary"},
+}
+
+
 @router.get("/jobs/{job_id}/download")
 async def download_job_output(
     job_id: UUID,
+    format: Annotated[Literal["dxf", "glb"], Query()] = "dxf",
     db: AsyncSession = Depends(get_db),
 ) -> FileResponse:
-    """Download the generated DXF file for a completed job."""
+    """Download the generated DXF (default) or GLB file for a completed job."""
     result = await db.execute(select(Job).where(Job.id == job_id))
     job = result.scalar_one_or_none()
     if not job:
@@ -134,11 +141,11 @@ async def download_job_output(
             detail="Job output is not ready for download",
         )
 
-    download_path = _resolve_download_path(job)
+    download_path = _resolve_download_path(job, download_format=format)
     return FileResponse(
         path=str(download_path),
-        media_type="application/dxf",
-        filename=f"drawlift-{job.id}.dxf",
+        media_type=DOWNLOAD_FORMATS[format]["media_type"],
+        filename=f"drawlift-{job.id}.{format}",
     )
 
 
@@ -181,17 +188,31 @@ async def list_jobs(
     )
 
 
-def _resolve_download_path(job: Job) -> Path:
-    """Resolve and validate a job output path before serving it to clients."""
+def _resolve_download_path(job: Job, *, download_format: str = "dxf") -> Path:
+    """Resolve and validate a job output path before serving it to clients.
+
+    The DXF output is derived from the persisted ``output_file`` column. Other
+    formats (e.g. GLB) live alongside it in the same trusted job output
+    directory, so we derive their path from the DXF's parent to keep the
+    ``.resolve()`` + ``relative_to()`` containment checks intact.
+    """
     if not job.output_file:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="No output file is available for this job",
         )
 
+    spec = DOWNLOAD_FORMATS.get(download_format)
+    if spec is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsupported download format: {download_format}",
+        )
+
     storage_base = Path(settings.STORAGE_PATH).resolve()
     job_storage_dir = (storage_base / str(job.id)).resolve()
-    candidate = Path(job.output_file).resolve()
+    dxf_path = Path(job.output_file).resolve()
+    candidate = (dxf_path.parent / spec["filename"]).resolve()
     try:
         job_storage_dir.relative_to(storage_base)
         candidate.relative_to(job_storage_dir)
@@ -201,9 +222,9 @@ def _resolve_download_path(job: Job) -> Path:
             detail="Invalid output path",
         ) from None
 
-    if candidate.suffix.lower() != ".dxf" or not candidate.is_file():
+    if candidate.suffix.lower() != spec["suffix"] or not candidate.is_file():
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="DXF output file not found",
+            detail=f"{download_format.upper()} output file not found",
         )
     return candidate

--- a/backend/app/pipeline/__init__.py
+++ b/backend/app/pipeline/__init__.py
@@ -5,14 +5,19 @@ from app.pipeline.orchestrator import Pipeline, create_pipeline
 from app.pipeline.primitives import (
     OpeningPrimitive,
     Point,
+    Point3D,
     Primitive,
     RoomPrimitive,
+    SlabGenerator,
+    SlabPrimitive,
     TextPrimitive,
     WallPrimitive,
+    WallSolidPrimitive,
 )
 from app.pipeline.progress import ProgressEvent, RedisProgressPublisher, get_progress_publisher
 from app.pipeline.steps.base import PipelineStep
 from app.pipeline.steps.dxf_writer import DxfWriterStep
+from app.pipeline.steps.extruder import WallExtruderStep
 from app.pipeline.steps.pdf_parser import PdfParserStep
 from app.pipeline.steps.preprocessor import OpenCVPreprocessor
 from app.pipeline.steps.segmenter import (
@@ -38,11 +43,16 @@ __all__ = [
     "ProgressEvent",
     "ProgressPublisher",
     "RedisProgressPublisher",
+    "Point3D",
     "RoomPrimitive",
     "SegmenterStep",
+    "SlabGenerator",
+    "SlabPrimitive",
     "TextPrimitive",
     "VectorizerStep",
+    "WallExtruderStep",
     "WallPrimitive",
+    "WallSolidPrimitive",
     "create_pipeline",
     "get_progress_publisher",
     "preload_configured_segmentation_model",

--- a/backend/app/pipeline/__init__.py
+++ b/backend/app/pipeline/__init__.py
@@ -18,6 +18,7 @@ from app.pipeline.progress import ProgressEvent, RedisProgressPublisher, get_pro
 from app.pipeline.steps.base import PipelineStep
 from app.pipeline.steps.dxf_writer import DxfWriterStep
 from app.pipeline.steps.extruder import WallExtruderStep
+from app.pipeline.steps.glb_writer import GlbWriterStep
 from app.pipeline.steps.pdf_parser import PdfParserStep
 from app.pipeline.steps.preprocessor import OpenCVPreprocessor
 from app.pipeline.steps.segmenter import (
@@ -31,6 +32,7 @@ from app.pipeline.steps.vectorizer import VectorizerStep
 __all__ = [
     "ClassicCVSegmenter",
     "DxfWriterStep",
+    "GlbWriterStep",
     "OpeningPrimitive",
     "OpenCVPreprocessor",
     "OnnxSemanticSegmenter",

--- a/backend/app/pipeline/primitives.py
+++ b/backend/app/pipeline/primitives.py
@@ -1,4 +1,4 @@
-"""CAD primitive dataclasses produced by vectorization steps."""
+"""CAD primitive dataclasses produced by vectorization and extrusion steps."""
 
 from __future__ import annotations
 
@@ -12,6 +12,15 @@ class Point:
 
     x: float
     y: float
+
+
+@dataclass(frozen=True)
+class Point3D:
+    """A 3D point in model coordinates (Z is the extrusion axis)."""
+
+    x: float
+    y: float
+    z: float
 
 
 @dataclass(frozen=True)
@@ -59,4 +68,136 @@ class TextPrimitive:
     kind: Literal["text"] = "text"
 
 
-Primitive: TypeAlias = WallPrimitive | OpeningPrimitive | RoomPrimitive | TextPrimitive
+@dataclass(frozen=True)
+class WallSolidPrimitive:
+    """A wall extruded into a 3D rectangular prism.
+
+    ``footprint`` is the four-corner base rectangle (at ``z = base_z``) derived
+    from the source wall centerline offset by half its thickness. The solid is
+    extruded upward by ``height`` along the Z axis.
+    """
+
+    footprint: tuple[Point, ...]
+    height: float
+    base_z: float = 0.0
+    thickness: float = 1.0
+    page: int = 1
+    kind: Literal["wall_solid"] = "wall_solid"
+
+    @property
+    def top_z(self) -> float:
+        """Return the elevation of the wall's top face."""
+        return self.base_z + self.height
+
+
+@dataclass(frozen=True)
+class SlabPrimitive:
+    """A horizontal floor or ceiling slab extruded a small thickness in Z."""
+
+    polygon: tuple[Point, ...]
+    elevation: float
+    thickness: float
+    level: Literal["floor", "ceiling"] = "floor"
+    page: int = 1
+    kind: Literal["slab"] = "slab"
+
+
+Primitive: TypeAlias = (
+    WallPrimitive
+    | OpeningPrimitive
+    | RoomPrimitive
+    | TextPrimitive
+    | WallSolidPrimitive
+    | SlabPrimitive
+)
+
+
+def wall_footprint(start: Point, end: Point, thickness: float) -> tuple[Point, ...]:
+    """Return the 4-corner base rectangle for a wall centerline and thickness.
+
+    The rectangle is centered on the ``start``→``end`` centerline and offset by
+    half the wall thickness along the segment normal, preserving the original
+    ``(start, end, thickness)`` geometry.
+    """
+    dx = end.x - start.x
+    dy = end.y - start.y
+    length = (dx * dx + dy * dy) ** 0.5
+    if length == 0:
+        # Degenerate wall: emit a small square so downstream writers stay robust.
+        half = max(thickness, 1.0) / 2.0
+        return (
+            Point(start.x - half, start.y - half),
+            Point(start.x + half, start.y - half),
+            Point(start.x + half, start.y + half),
+            Point(start.x - half, start.y + half),
+        )
+
+    half_thickness = max(thickness, 1.0) / 2.0
+    # Unit normal to the centerline.
+    nx = -dy / length
+    ny = dx / length
+    ox = nx * half_thickness
+    oy = ny * half_thickness
+    return (
+        Point(start.x + ox, start.y + oy),
+        Point(end.x + ox, end.y + oy),
+        Point(end.x - ox, end.y - oy),
+        Point(start.x - ox, start.y - oy),
+    )
+
+
+class SlabGenerator:
+    """Build floor/ceiling slab primitives from detected room polygons."""
+
+    def __init__(self, *, thickness: float = 0.2) -> None:
+        """Create a slab generator with a default slab thickness in metres."""
+        if thickness <= 0:
+            raise ValueError("slab thickness must be greater than zero")
+        self.thickness = thickness
+
+    def floor_slab(self, rooms: list[RoomPrimitive], *, page: int = 1) -> SlabPrimitive | None:
+        """Return a single slab at ``z = 0`` covering the union of room polygons."""
+        footprint = _union_bounds(rooms)
+        if footprint is None:
+            return None
+        return SlabPrimitive(
+            polygon=footprint,
+            elevation=0.0,
+            thickness=self.thickness,
+            level="floor",
+            page=page,
+        )
+
+    def ceiling_slab(
+        self, rooms: list[RoomPrimitive], *, elevation: float, page: int = 1
+    ) -> SlabPrimitive | None:
+        """Return an optional ceiling slab at ``z = elevation`` over the rooms."""
+        footprint = _union_bounds(rooms)
+        if footprint is None:
+            return None
+        return SlabPrimitive(
+            polygon=footprint,
+            elevation=elevation,
+            thickness=self.thickness,
+            level="ceiling",
+            page=page,
+        )
+
+
+def _union_bounds(rooms: list[RoomPrimitive]) -> tuple[Point, ...] | None:
+    """Return the axis-aligned bounding rectangle of the union of room polygons."""
+    points = [point for room in rooms for point in room.polygon]
+    if not points:
+        return None
+    min_x = min(point.x for point in points)
+    min_y = min(point.y for point in points)
+    max_x = max(point.x for point in points)
+    max_y = max(point.y for point in points)
+    if min_x == max_x or min_y == max_y:
+        return None
+    return (
+        Point(min_x, min_y),
+        Point(max_x, min_y),
+        Point(max_x, max_y),
+        Point(min_x, max_y),
+    )

--- a/backend/app/pipeline/steps/dxf_writer.py
+++ b/backend/app/pipeline/steps/dxf_writer.py
@@ -12,8 +12,10 @@ from app.pipeline.primitives import (
     OpeningPrimitive,
     Primitive,
     RoomPrimitive,
+    SlabPrimitive,
     TextPrimitive,
     WallPrimitive,
+    WallSolidPrimitive,
 )
 from app.pipeline.steps.base import PipelineStep
 
@@ -22,7 +24,10 @@ LAYER_DOORS = "DOORS"
 LAYER_WINDOWS = "WINDOWS"
 LAYER_ROOMS = "ROOMS"
 LAYER_TEXT = "TEXT"
+LAYER_WALLS_3D = "WALLS_3D"
+LAYER_SLABS = "SLABS"
 DXF_LAYERS: tuple[str, ...] = (LAYER_WALLS, LAYER_DOORS, LAYER_WINDOWS, LAYER_ROOMS, LAYER_TEXT)
+DXF_3D_LAYERS: tuple[str, ...] = (LAYER_WALLS_3D, LAYER_SLABS)
 
 
 class DxfWriterStep(PipelineStep):
@@ -77,13 +82,23 @@ class DxfWriterStep(PipelineStep):
                 )
                 text.dxf.insert = (primitive.insertion.x, primitive.insertion.y)
                 text.dxf.rotation = primitive.rotation
+            elif isinstance(primitive, WallSolidPrimitive):
+                _add_wall_solid(modelspace, primitive)
+            elif isinstance(primitive, SlabPrimitive):
+                _add_slab(modelspace, primitive)
 
         document.saveas(output_path)
+
+        has_3d = any(
+            isinstance(primitive, WallSolidPrimitive | SlabPrimitive) for primitive in primitives
+        )
+        layers = list(DXF_LAYERS) + (list(DXF_3D_LAYERS) if has_3d else [])
 
         context.output_path = output_path
         context.metadata["output_format"] = "dxf"
         context.metadata["output_path"] = output_path
-        context.metadata["dxf_layers"] = list(DXF_LAYERS)
+        context.metadata["dxf_layers"] = layers
+        context.metadata["dxf_is_3d"] = has_3d
 
         self.publish_progress(
             context,
@@ -112,6 +127,8 @@ def _ensure_layers(document: ezdxf.document.Drawing) -> None:
         LAYER_WINDOWS: 4,
         LAYER_ROOMS: 2,
         LAYER_TEXT: 1,
+        LAYER_WALLS_3D: 8,
+        LAYER_SLABS: 9,
     }
     for layer, colour in layer_colours.items():
         if layer not in document.layers:
@@ -121,6 +138,39 @@ def _ensure_layers(document: ezdxf.document.Drawing) -> None:
 def _lineweight(thickness: float) -> int:
     """Map estimated wall thickness to a valid DXF lineweight value."""
     return max(13, min(211, int(round(thickness * 10))))
+
+
+def _add_wall_solid(modelspace: Any, primitive: WallSolidPrimitive) -> None:
+    """Render an extruded wall as top/bottom faces plus side 3DFACE walls."""
+    base = [(point.x, point.y, primitive.base_z) for point in primitive.footprint]
+    top = [(point.x, point.y, primitive.top_z) for point in primitive.footprint]
+    if len(base) < 3:
+        return
+
+    dxfattribs = {"layer": LAYER_WALLS_3D}
+    modelspace.add_3dface(base, dxfattribs=dxfattribs)
+    modelspace.add_3dface(top, dxfattribs=dxfattribs)
+    for index in range(len(base)):
+        next_index = (index + 1) % len(base)
+        side = [
+            base[index],
+            base[next_index],
+            top[next_index],
+            top[index],
+        ]
+        modelspace.add_3dface(side, dxfattribs=dxfattribs)
+
+
+def _add_slab(modelspace: Any, primitive: SlabPrimitive) -> None:
+    """Render a slab as a closed 3D polyline outline at its elevation."""
+    points = [(point.x, point.y, primitive.elevation) for point in primitive.polygon]
+    if len(points) < 3:
+        return
+    modelspace.add_polyline3d(
+        [*points, points[0]],
+        dxfattribs={"layer": LAYER_SLABS},
+    )
+    modelspace.add_3dface(points[:4], dxfattribs={"layer": LAYER_SLABS})
 
 
 def _add_opening_block(modelspace: Any, primitive: OpeningPrimitive, layer: str) -> None:

--- a/backend/app/pipeline/steps/extruder.py
+++ b/backend/app/pipeline/steps/extruder.py
@@ -1,0 +1,126 @@
+"""3D extrusion step that lifts 2D wall vectors into solid geometry."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from app.pipeline.context import PipelineContext
+from app.pipeline.primitives import (
+    Primitive,
+    RoomPrimitive,
+    SlabGenerator,
+    SlabPrimitive,
+    WallPrimitive,
+    WallSolidPrimitive,
+    wall_footprint,
+)
+from app.pipeline.steps.base import PipelineStep
+
+DEFAULT_FLOOR_HEIGHT_M = 3.0
+DEFAULT_SLAB_THICKNESS_M = 0.2
+
+
+class WallExtruderStep(PipelineStep):
+    """Extrude wall centerlines into 3D prisms and add floor/ceiling slabs.
+
+    The step consumes the 2D ``WallPrimitive`` / ``RoomPrimitive`` output from
+    vectorization and appends ``WallSolidPrimitive`` and ``SlabPrimitive``
+    instances to the context. Existing 2D primitives are preserved so the DXF
+    writer can still emit the layered plan alongside the 3D model.
+    """
+
+    name = "3D Extrusion"
+    progress = 85
+
+    def __init__(
+        self,
+        *,
+        floor_height_m: float | None = None,
+        slab_thickness_m: float = DEFAULT_SLAB_THICKNESS_M,
+        include_ceiling: bool = False,
+    ) -> None:
+        """Create the extruder with optional floor height and slab settings."""
+        if floor_height_m is not None and floor_height_m <= 0:
+            raise ValueError("floor_height_m must be greater than zero")
+        if slab_thickness_m <= 0:
+            raise ValueError("slab_thickness_m must be greater than zero")
+        self.floor_height_m = floor_height_m
+        self.slab_thickness_m = slab_thickness_m
+        self.include_ceiling = include_ceiling
+
+    def execute(self, context: PipelineContext) -> PipelineContext:
+        """Extrude walls into prisms and add slabs, then report 85% progress."""
+        primitives = [cast(Primitive, primitive) for primitive in context.primitives]
+
+        floor_height = self._resolve_floor_height(context)
+        include_ceiling = bool(context.config.get("include_ceiling", self.include_ceiling))
+        slab_thickness = float(context.config.get("slab_thickness_m", self.slab_thickness_m))
+
+        walls = [primitive for primitive in primitives if isinstance(primitive, WallPrimitive)]
+        rooms = [primitive for primitive in primitives if isinstance(primitive, RoomPrimitive)]
+
+        solids: list[WallSolidPrimitive] = [
+            self._extrude_wall(wall, floor_height) for wall in walls
+        ]
+
+        slabs = self._build_slabs(
+            rooms,
+            floor_height=floor_height,
+            slab_thickness=slab_thickness,
+            include_ceiling=include_ceiling,
+        )
+
+        context.primitives = [*primitives, *solids, *slabs]
+        context.metadata["floor_height_m"] = floor_height
+        context.metadata["slab_thickness_m"] = slab_thickness
+        context.metadata["wall_solid_count"] = len(solids)
+        context.metadata["slab_count"] = len(slabs)
+
+        self.publish_progress(
+            context,
+            progress=self.progress,
+            message=f"Extruded {len(solids)} wall(s) and {len(slabs)} slab(s)",
+        )
+        return context
+
+    def _resolve_floor_height(self, context: PipelineContext) -> float:
+        """Resolve the floor height from the step override or job config."""
+        if self.floor_height_m is not None:
+            return self.floor_height_m
+        configured = context.config.get("floor_height_m", DEFAULT_FLOOR_HEIGHT_M)
+        height = float(configured)
+        if height <= 0:
+            raise ValueError("floor_height_m must be greater than zero")
+        return height
+
+    @staticmethod
+    def _extrude_wall(wall: WallPrimitive, floor_height: float) -> WallSolidPrimitive:
+        """Turn one wall centerline + thickness into a rectangular prism."""
+        footprint = wall_footprint(wall.start, wall.end, wall.thickness)
+        return WallSolidPrimitive(
+            footprint=footprint,
+            height=floor_height,
+            base_z=0.0,
+            thickness=wall.thickness,
+            page=wall.page,
+        )
+
+    def _build_slabs(
+        self,
+        rooms: list[RoomPrimitive],
+        *,
+        floor_height: float,
+        slab_thickness: float,
+        include_ceiling: bool,
+    ) -> list[SlabPrimitive]:
+        """Generate a floor slab and optional ceiling slab from room polygons."""
+        generator = SlabGenerator(thickness=slab_thickness)
+        slabs: list[SlabPrimitive] = []
+        floor = generator.floor_slab(rooms)
+        if floor is not None:
+            slabs.append(floor)
+        if include_ceiling:
+            ceiling = generator.ceiling_slab(rooms, elevation=floor_height)
+            if ceiling is not None:
+                slabs.append(ceiling)
+        return slabs

--- a/backend/app/pipeline/steps/glb_writer.py
+++ b/backend/app/pipeline/steps/glb_writer.py
@@ -1,0 +1,151 @@
+"""GLB (binary glTF) writer step for extruded 3D primitives."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import trimesh
+
+from app.pipeline.context import PipelineContext
+from app.pipeline.primitives import (
+    Primitive,
+    SlabPrimitive,
+    WallSolidPrimitive,
+)
+from app.pipeline.steps.base import PipelineStep
+
+
+class GlbWriterStep(PipelineStep):
+    """Export extruded wall/slab geometry to a single self-contained GLB file.
+
+    GLB (binary glTF) is a compact, self-contained format that opens directly in
+    Blender and any online glTF viewer, satisfying US-024. The step reads the 3D
+    primitives produced by :class:`WallExtruderStep` and writes ``output.glb``
+    alongside the DXF output.
+    """
+
+    name = "GLB Writer"
+    progress = 97
+
+    def __init__(self, output_path: Path | str | None = None) -> None:
+        """Create the writer with an optional output path override."""
+        self.output_path = Path(output_path) if output_path is not None else None
+
+    def execute(self, context: PipelineContext) -> PipelineContext:
+        """Build a mesh scene from 3D primitives and export it as GLB."""
+        primitives = [cast(Primitive, primitive) for primitive in context.primitives]
+        meshes = _build_meshes(primitives)
+        if not meshes:
+            raise ValueError("GlbWriterStep requires extruded 3D primitives on the context")
+
+        output_path = self._resolve_output_path(context)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        scene = trimesh.Scene(meshes)
+        scene.export(str(output_path), file_type="glb")
+
+        context.metadata["glb_output_path"] = output_path
+        context.metadata["glb_mesh_count"] = len(meshes)
+
+        self.publish_progress(
+            context,
+            progress=self.progress,
+            message=f"Wrote GLB output to {output_path.name}",
+        )
+        return context
+
+    def _resolve_output_path(self, context: PipelineContext) -> Path:
+        """Resolve the output GLB path under the current job storage directory."""
+        if self.output_path is not None:
+            return self.output_path
+
+        configured_path: Any = context.config.get("glb_output_path")
+        if configured_path is not None:
+            return Path(str(configured_path))
+
+        return context.input_path.parent / context.job_id / "output" / "output.glb"
+
+
+def _build_meshes(primitives: list[Primitive]) -> list[trimesh.Trimesh]:
+    """Convert 3D primitives into extruded trimesh boxes/prisms."""
+    meshes: list[trimesh.Trimesh] = []
+    for primitive in primitives:
+        if isinstance(primitive, WallSolidPrimitive):
+            mesh = _extrude_polygon(
+                [(point.x, point.y) for point in primitive.footprint],
+                base_z=primitive.base_z,
+                height=primitive.height,
+            )
+            if mesh is not None:
+                meshes.append(mesh)
+        elif isinstance(primitive, SlabPrimitive):
+            mesh = _extrude_polygon(
+                [(point.x, point.y) for point in primitive.polygon],
+                base_z=primitive.elevation,
+                height=primitive.thickness,
+            )
+            if mesh is not None:
+                meshes.append(mesh)
+    return meshes
+
+
+def _extrude_polygon(
+    points: list[tuple[float, float]],
+    *,
+    base_z: float,
+    height: float,
+) -> trimesh.Trimesh | None:
+    """Extrude a 2D polygon into a 3D prism between ``base_z`` and ``base_z + height``."""
+    if len(points) < 3 or height <= 0:
+        return None
+    try:
+        from shapely.geometry import Polygon
+    except ImportError:  # pragma: no cover - shapely ships with trimesh extras
+        return _extrude_quad(points, base_z=base_z, height=height)
+
+    polygon = Polygon(points)
+    if not polygon.is_valid or polygon.area == 0:
+        polygon = polygon.buffer(0)
+    if polygon.is_empty or polygon.area == 0:
+        return None
+
+    mesh = trimesh.creation.extrude_polygon(polygon, height=height)
+    mesh.apply_translation((0.0, 0.0, base_z))
+    return mesh
+
+
+def _extrude_quad(
+    points: list[tuple[float, float]],
+    *,
+    base_z: float,
+    height: float,
+) -> trimesh.Trimesh | None:
+    """Fallback prism builder for a 4-corner footprint without shapely."""
+    if len(points) < 4:
+        return None
+    quad = points[:4]
+    top_z = base_z + height
+    vertices = np.array(
+        [[x, y, base_z] for x, y in quad] + [[x, y, top_z] for x, y in quad],
+        dtype=np.float64,
+    )
+    faces = np.array(
+        [
+            [0, 1, 2],
+            [0, 2, 3],
+            [4, 6, 5],
+            [4, 7, 6],
+            [0, 4, 5],
+            [0, 5, 1],
+            [1, 5, 6],
+            [1, 6, 2],
+            [2, 6, 7],
+            [2, 7, 3],
+            [3, 7, 4],
+            [3, 4, 0],
+        ],
+        dtype=np.int64,
+    )
+    return trimesh.Trimesh(vertices=vertices, faces=faces, process=False)

--- a/backend/app/schemas/job.py
+++ b/backend/app/schemas/job.py
@@ -13,7 +13,9 @@ class JobConfig(BaseModel):
     mode: Literal["2d", "3d"] = "2d"
     dpi: int = Field(default=300, ge=72, le=1200)
     floor_height_m: float = Field(default=3.0, ge=0.5, le=10.0)
-    output_format: Literal["dxf", "dwg"] = "dxf"
+    slab_thickness_m: float = Field(default=0.2, ge=0.05, le=2.0)
+    include_ceiling: bool = False
+    output_format: Literal["dxf", "dwg", "glb"] = "dxf"
     segmenter: Literal["ml", "classic"] = "classic"
 
 

--- a/backend/app/tasks/placeholder.py
+++ b/backend/app/tasks/placeholder.py
@@ -13,12 +13,15 @@ from app.core.database import async_session
 from app.models.job import Job
 from app.pipeline import (
     DxfWriterStep,
+    GlbWriterStep,
     OpenCVPreprocessor,
     PdfParserStep,
     Pipeline,
     PipelineContext,
+    PipelineStep,
     SegmenterStep,
     VectorizerStep,
+    WallExtruderStep,
 )
 from app.pipeline.progress import get_progress_publisher
 from app.tasks.celery_app import celery_app
@@ -80,14 +83,20 @@ async def _process_job_async(job_id: str, config: dict[str, Any]) -> str:
             config=config,
             progress_publisher=get_progress_publisher(),
         )
-        pipeline = Pipeline.from_steps(
+
+        steps: list[PipelineStep] = [
             PdfParserStep(output_dir=job_dir / "pages"),
             OpenCVPreprocessor(output_dir=job_dir / "preprocessed"),
             SegmenterStep(output_dir=job_dir / "masks"),
             VectorizerStep(),
-            DxfWriterStep(output_path=job_dir / "output" / "output.dxf"),
-            publish_step_progress=False,
-        )
+        ]
+        if config.get("mode") == "3d":
+            steps.append(WallExtruderStep())
+        steps.append(DxfWriterStep(output_path=job_dir / "output" / "output.dxf"))
+        if config.get("mode") == "3d":
+            steps.append(GlbWriterStep(output_path=job_dir / "output" / "output.glb"))
+
+        pipeline = Pipeline.from_steps(*steps, publish_step_progress=False)
 
         try:
             result_context = pipeline.run(context)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,6 +12,9 @@ opencv-python-headless==4.*
 numpy==2.*
 onnxruntime==1.*
 ezdxf==1.*
+trimesh==4.*
+shapely==2.*
+manifold3d==3.*
 ruff==0.8.*
 mypy==1.*
 pre-commit==4.*

--- a/backend/tests/test_dxf_writer_step.py
+++ b/backend/tests/test_dxf_writer_step.py
@@ -12,10 +12,12 @@ from app.pipeline.primitives import (
     OpeningPrimitive,
     Point,
     RoomPrimitive,
+    SlabPrimitive,
     TextPrimitive,
     WallPrimitive,
+    WallSolidPrimitive,
 )
-from app.pipeline.steps.dxf_writer import DXF_LAYERS
+from app.pipeline.steps.dxf_writer import DXF_3D_LAYERS, DXF_LAYERS
 
 
 class RecordingPublisher:
@@ -106,3 +108,28 @@ def test_dxf_writer_requires_primitives(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="requires primitives"):
         DxfWriterStep(output_path=tmp_path / "output.dxf").execute(context)
+
+
+def test_dxf_writer_emits_3d_entities_for_solids(tmp_path: Path) -> None:
+    """3D solids and slabs produce 3DFACE entities on dedicated layers."""
+    output_path = tmp_path / "output" / "output.dxf"
+    footprint = (Point(0, 0), Point(100, 0), Point(100, 10), Point(0, 10))
+    slab_polygon = (Point(0, 0), Point(100, 0), Point(100, 80), Point(0, 80))
+    context = PipelineContext(
+        job_id="job-dxf-3d",
+        input_path=tmp_path / "input.pdf",
+        primitives=[
+            WallPrimitive(start=Point(0, 5), end=Point(100, 5), thickness=10),
+            WallSolidPrimitive(footprint=footprint, height=3.0, thickness=10),
+            SlabPrimitive(polygon=slab_polygon, elevation=0.0, thickness=0.2, level="floor"),
+        ],
+    )
+
+    result = DxfWriterStep(output_path=output_path).execute(context)
+
+    assert result.metadata["dxf_is_3d"] is True
+    document = ezdxf.readfile(output_path)
+    layer_names = {layer.dxf.name for layer in document.layers}
+    assert set(DXF_3D_LAYERS).issubset(layer_names)
+    entity_types = {entity.dxftype() for entity in document.modelspace()}
+    assert "3DFACE" in entity_types

--- a/backend/tests/test_extruder_step.py
+++ b/backend/tests/test_extruder_step.py
@@ -1,0 +1,133 @@
+"""Tests for the 3D wall extrusion step."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.pipeline import PipelineContext, WallExtruderStep
+from app.pipeline.primitives import (
+    Point,
+    Primitive,
+    RoomPrimitive,
+    SlabPrimitive,
+    WallPrimitive,
+    WallSolidPrimitive,
+)
+
+
+class RecordingPublisher:
+    """In-memory progress publisher for extruder tests."""
+
+    def __init__(self) -> None:
+        self.events: list[dict[str, object]] = []
+
+    def publish(
+        self,
+        *,
+        job_id: str,
+        status: str,
+        progress: int,
+        step: str,
+        message: str | None = None,
+    ) -> None:
+        """Record a progress event."""
+        self.events.append(
+            {
+                "job_id": job_id,
+                "status": status,
+                "progress": progress,
+                "step": step,
+                "message": message,
+            }
+        )
+
+
+def _context(**kwargs: object) -> PipelineContext:
+    """Build a pipeline context seeded with vectorized primitives."""
+    primitives: list[Primitive] = [
+        WallPrimitive(start=Point(0, 0), end=Point(100, 0), thickness=10),
+        RoomPrimitive(polygon=(Point(0, 0), Point(100, 0), Point(100, 80), Point(0, 80))),
+    ]
+    return PipelineContext(
+        job_id="job-3d",
+        input_path=Path("/tmp/input.pdf"),
+        primitives=list(primitives),
+        config=dict(kwargs),
+    )
+
+
+def test_extruder_creates_wall_solids_with_floor_height() -> None:
+    """Each wall becomes a prism with floor height as its Z dimension."""
+    context = _context()
+
+    result = WallExtruderStep(floor_height_m=3.0).execute(context)
+
+    solids = [p for p in result.primitives if isinstance(p, WallSolidPrimitive)]
+    assert len(solids) == 1
+    solid = solids[0]
+    assert solid.height == 3.0
+    assert solid.base_z == 0.0
+    assert solid.top_z == 3.0
+    assert solid.thickness == 10
+    assert len(solid.footprint) == 4
+
+
+def test_extruder_respects_original_wall_geometry() -> None:
+    """The extruded footprint is centered on the original centerline and thickness."""
+    context = _context()
+
+    result = WallExtruderStep(floor_height_m=2.5).execute(context)
+    solid = next(p for p in result.primitives if isinstance(p, WallSolidPrimitive))
+
+    ys = [point.y for point in solid.footprint]
+    # A horizontal 10-unit-thick wall spans y in [-5, 5] around the centerline.
+    assert min(ys) == -5.0
+    assert max(ys) == 5.0
+
+
+def test_extruder_uses_config_floor_height_when_not_overridden() -> None:
+    """Floor height falls back to job config, defaulting to 3.0m."""
+    context = _context(floor_height_m=4.2)
+
+    result = WallExtruderStep().execute(context)
+    solid = next(p for p in result.primitives if isinstance(p, WallSolidPrimitive))
+
+    assert solid.height == 4.2
+
+
+def test_extruder_adds_floor_slab_and_optional_ceiling() -> None:
+    """A floor slab is always emitted; ceilings only when enabled."""
+    floor_only = WallExtruderStep(floor_height_m=3.0).execute(_context())
+    slabs = [p for p in floor_only.primitives if isinstance(p, SlabPrimitive)]
+    assert len(slabs) == 1
+    assert slabs[0].level == "floor"
+    assert slabs[0].elevation == 0.0
+
+    with_ceiling = WallExtruderStep(floor_height_m=3.0, include_ceiling=True).execute(_context())
+    ceiling_slabs = [
+        p for p in with_ceiling.primitives if isinstance(p, SlabPrimitive) and p.level == "ceiling"
+    ]
+    assert len(ceiling_slabs) == 1
+    assert ceiling_slabs[0].elevation == 3.0
+
+
+def test_extruder_reports_eighty_five_percent_progress() -> None:
+    """Execution reports the US-021 85 percent progress milestone."""
+    publisher = RecordingPublisher()
+    context = _context()
+    context.progress_publisher = publisher
+
+    WallExtruderStep(floor_height_m=3.0).execute(context)
+
+    assert publisher.events[-1]["progress"] == 85
+    assert publisher.events[-1]["step"] == "3D Extrusion"
+
+
+def test_extruder_preserves_existing_2d_primitives() -> None:
+    """Original 2D primitives remain so the DXF plan can still be written."""
+    context = _context()
+
+    result = WallExtruderStep(floor_height_m=3.0).execute(context)
+
+    assert any(isinstance(p, WallPrimitive) for p in result.primitives)
+    assert any(isinstance(p, RoomPrimitive) for p in result.primitives)

--- a/backend/tests/test_glb_writer_step.py
+++ b/backend/tests/test_glb_writer_step.py
@@ -1,0 +1,95 @@
+"""Tests for the GLB (binary glTF) writer step."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import trimesh
+
+from app.pipeline import GlbWriterStep, PipelineContext
+from app.pipeline.primitives import (
+    Point,
+    Primitive,
+    SlabPrimitive,
+    WallSolidPrimitive,
+)
+
+
+class RecordingPublisher:
+    """In-memory progress publisher for GLB writer tests."""
+
+    def __init__(self) -> None:
+        self.events: list[dict[str, object]] = []
+
+    def publish(
+        self,
+        *,
+        job_id: str,
+        status: str,
+        progress: int,
+        step: str,
+        message: str | None = None,
+    ) -> None:
+        """Record a progress event."""
+        self.events.append(
+            {
+                "job_id": job_id,
+                "status": status,
+                "progress": progress,
+                "step": step,
+                "message": message,
+            }
+        )
+
+
+def _solids() -> list[Primitive]:
+    """Return a wall solid and a floor slab for extrusion."""
+    footprint = (Point(0, 0), Point(100, 0), Point(100, 10), Point(0, 10))
+    slab_polygon = (Point(0, 0), Point(100, 0), Point(100, 80), Point(0, 80))
+    return [
+        WallSolidPrimitive(footprint=footprint, height=3.0, thickness=10),
+        SlabPrimitive(polygon=slab_polygon, elevation=0.0, thickness=0.2, level="floor"),
+    ]
+
+
+def test_glb_writer_produces_loadable_single_file(tmp_path: Path) -> None:
+    """The GLB is a single self-contained file loadable by any glTF reader."""
+    output_path = tmp_path / "output" / "output.glb"
+    context = PipelineContext(
+        job_id="job-glb",
+        input_path=tmp_path / "input.pdf",
+        primitives=_solids(),
+    )
+
+    result = GlbWriterStep(output_path=output_path).execute(context)
+
+    assert output_path.exists()
+    assert output_path.stat().st_size > 0
+    loaded = trimesh.load(output_path, file_type="glb")
+    assert loaded is not None
+    assert result.metadata["glb_mesh_count"] == 2
+
+
+def test_glb_writer_reports_progress(tmp_path: Path) -> None:
+    """Execution reports a progress milestone for the GLB export."""
+    publisher = RecordingPublisher()
+    context = PipelineContext(
+        job_id="job-glb",
+        input_path=tmp_path / "input.pdf",
+        primitives=_solids(),
+        progress_publisher=publisher,
+    )
+
+    GlbWriterStep(output_path=tmp_path / "output.glb").execute(context)
+
+    assert publisher.events[-1]["step"] == "GLB Writer"
+    assert publisher.events[-1]["progress"] == 97
+
+
+def test_glb_writer_requires_3d_primitives(tmp_path: Path) -> None:
+    """Writer fails clearly when no extruded geometry is present."""
+    context = PipelineContext(job_id="job-glb", input_path=tmp_path / "input.pdf")
+
+    with pytest.raises(ValueError, match="requires extruded 3D primitives"):
+        GlbWriterStep(output_path=tmp_path / "output.glb").execute(context)

--- a/backend/tests/test_jobs_download.py
+++ b/backend/tests/test_jobs_download.py
@@ -12,12 +12,19 @@ from app.api.v1.jobs import _resolve_download_path, download_job_output
 from app.models.job import Job
 
 
-def create_job(storage_path: Path, *, status: str = "completed") -> Job:
+def create_job(
+    storage_path: Path,
+    *,
+    status: str = "completed",
+    with_glb: bool = False,
+) -> Job:
     """Create an in-memory job model with a valid output file."""
     job_id = uuid.uuid4()
     output_path = storage_path / str(job_id) / "output" / "output.dxf"
     output_path.parent.mkdir(parents=True)
     output_path.write_text("0\nSECTION\n2\nEOF\n", encoding="utf-8")
+    if with_glb:
+        (output_path.parent / "output.glb").write_bytes(b"glTF\x02\x00\x00\x00")
     return Job(
         id=job_id,
         status=status,
@@ -98,3 +105,59 @@ async def test_download_endpoint_rejects_incomplete_jobs(tmp_path: Path) -> None
         await download_job_output(job.id, db=StubSession())  # type: ignore[arg-type]
 
     assert exc_info.value.status_code == 409
+
+
+def test_resolve_download_path_serves_glb_alongside_dxf(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The GLB output is served from the same trusted job output directory."""
+    monkeypatch.setattr("app.api.v1.jobs.settings.STORAGE_PATH", str(tmp_path))
+    job = create_job(tmp_path, with_glb=True)
+
+    resolved = _resolve_download_path(job, download_format="glb")
+
+    assert resolved.suffix == ".glb"
+    assert resolved.is_file()
+
+
+def test_resolve_download_path_missing_glb_returns_404(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Requesting GLB for a 2D job without a GLB output returns 404."""
+    monkeypatch.setattr("app.api.v1.jobs.settings.STORAGE_PATH", str(tmp_path))
+    job = create_job(tmp_path)
+
+    with pytest.raises(HTTPException) as exc_info:
+        _resolve_download_path(job, download_format="glb")
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_download_endpoint_returns_glb_content_disposition(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The download endpoint serves GLB with a model/gltf-binary media type."""
+    monkeypatch.setattr("app.api.v1.jobs.settings.STORAGE_PATH", str(tmp_path))
+    job = create_job(tmp_path, with_glb=True)
+
+    class StubResult:
+        def scalar_one_or_none(self) -> Job:
+            return job
+
+    class StubSession:
+        async def execute(self, _statement: object) -> StubResult:
+            return StubResult()
+
+    response = await download_job_output(
+        job.id,
+        format="glb",
+        db=StubSession(),  # type: ignore[arg-type]
+    )
+
+    assert response.media_type == "model/gltf-binary"
+    assert response.filename == f"drawlift-{job.id}.glb"
+    assert f"drawlift-{job.id}.glb" in response.headers["content-disposition"]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,17 +8,21 @@
       "name": "ai-file-converter-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@react-three/drei": "^9.114.0",
+        "@react-three/fiber": "^8.17.0",
         "next": "^15.5.21",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "react-dropzone": "^14.2.0",
         "sonner": "^1.4.0",
+        "three": "^0.169.0",
         "zod": "^3.23.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
+        "@types/three": "^0.169.0",
         "autoprefixer": "^10.4.0",
         "eslint": "^9.39.5",
         "eslint-config-next": "^16.2.11",
@@ -251,6 +255,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1170,6 +1183,24 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -1423,6 +1454,195 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@react-spring/animated": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
+      "integrity": "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/core": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.5.tgz",
+      "integrity": "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/rafz": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.5.tgz",
+      "integrity": "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/shared": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.5.tgz",
+      "integrity": "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/rafz": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/three": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/three/-/three-9.7.5.tgz",
+      "integrity": "sha512-RxIsCoQfUqOS3POmhVHa1wdWS0wyHAUway73uRLp3GAL5U2iYVNdnzQsep6M2NZ994BlW8TcKuMtQHUqOsy6WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/core": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": ">=6.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "three": ">=0.126"
+      }
+    },
+    "node_modules/@react-spring/types": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
+      "integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
+      "license": "MIT"
+    },
+    "node_modules/@react-three/drei": {
+      "version": "9.122.0",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.122.0.tgz",
+      "integrity": "sha512-SEO/F/rBCTjlLez7WAlpys+iGe9hty4rNgjZvgkQeXFSiwqD4Hbk/wNHMAbdd8vprO2Aj81mihv4dF5bC7D0CA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@react-spring/three": "~9.7.5",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^2.9.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "react-composer": "^5.0.3",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.7.8",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.0",
+        "tunnel-rat": "^0.1.2",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^8",
+        "react": "^18",
+        "react-dom": "^18",
+        "three": ">=0.137"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.18.0.tgz",
+      "integrity": "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/react-reconciler": "^0.26.7",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^1.0.6",
+        "react-reconciler": "^0.27.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.21.0",
+        "suspend-react": "^0.1.3",
+        "zustand": "^3.7.1"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=18 <19",
+        "react-dom": ">=18 <19",
+        "react-native": ">=0.64",
+        "three": ">=0.133"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/zustand": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1439,6 +1659,12 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -1449,6 +1675,12 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -1481,18 +1713,22 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.31",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1508,6 +1744,41 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.26.7.tgz",
+      "integrity": "sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.169.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.169.0.tgz",
+      "integrity": "sha512-oan7qCgJBt03wIaK+4xPWclYRPG9wzcg7Z2f5T8xYTNEF95kh0t0lklxLLYBDo7gQiGLYzE6iF4ta7nXF2bcsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.18.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.65.0",
@@ -2095,6 +2366,30 @@
         "win32"
       ]
     },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.71",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.71.tgz",
+      "integrity": "sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -2465,6 +2760,26 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.1.tgz",
@@ -2476,6 +2791,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -2551,6 +2875,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -2619,6 +2967,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-2.10.1.tgz",
+      "integrity": "sha512-KnaKdcvkBJ1Irbrzl8XD6WtZltkRjp869Jx8c0ujs9K+9WD+1D7ryBsCiVqJYUqt6i/HR5FxT7RLASieUD+Q5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2746,11 +3103,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2778,7 +3152,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -2903,6 +3276,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2939,6 +3321,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3743,6 +4131,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -4041,6 +4435,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -4165,6 +4565,32 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4174,6 +4600,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -4503,6 +4935,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -4659,7 +5097,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -4678,6 +5115,27 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/its-fine": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
+      "integrity": "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0"
+      }
+    },
+    "node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/jiti": {
@@ -4826,6 +5284,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -4891,6 +5358,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4910,6 +5387,21 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -5368,7 +5860,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5615,6 +6106,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5639,6 +6136,16 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
       }
     },
     "node_modules/prop-types": {
@@ -5695,6 +6202,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-composer": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/react-composer/-/react-composer-5.0.3.tgz",
+      "integrity": "sha512-1uWd07EME6XZvMfapwZmc7NgCZqDemcvicRi3wMJzXsQLvZ3L7fTHVyPy1bZdnWXM4iPjYuNE+uJ41MLKeTtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.6.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -5730,6 +6249,46 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.27.0.tgz",
+      "integrity": "sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.21.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/react-reconciler/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -5796,6 +6355,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -6052,7 +6620,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6065,7 +6632,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6171,6 +6737,32 @@
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
@@ -6396,6 +6988,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
@@ -6479,6 +7080,45 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/three": {
+      "version": "0.169.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.169.0.tgz",
+      "integrity": "sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.7.8.tgz",
+      "integrity": "sha512-BGEZTOIC14U0XIRw3tO4jY7IjP7n7v24nv9JXS1CyeVRWOCkcOMhRnmENUjuV39gktAw4Ofhr0OvIAiTspQrrw==",
+      "deprecated": "Deprecated due to three.js version incompatibility. Please use v0.8.0, instead.",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.151.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.11",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.11.tgz",
+      "integrity": "sha512-3JyEFWGjFn7zHmoa9+zG1BmW7X2okcmAB+0Cnu9UFbVs/jCBnl2A8o065ZlXiw145K3eBM3uLuzrYXC0RK7eDg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -6540,6 +7180,36 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/troika-three-text": {
+      "version": "0.52.5",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.5.tgz",
+      "integrity": "sha512-Ry3jRhic9pzcY4JduSvRRyDmVOSqEW19gT4vtK+aCiPNVcDlmkxvGG0YbFd36RTDq1wExOupXnvNF/j1oiHHDA==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.5",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.5",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.5.tgz",
+      "integrity": "sha512-WsePbcX8RtfidRfsxK1eCZCjF81ZDzAKHH/evLs0hdV2wpoCb0vArGZHdzdOJrSS3k4zfdtbKDaBh8+phkrYnw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -6591,6 +7261,43 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6826,6 +7533,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -6833,11 +7549,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6988,6 +7723,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,17 +11,21 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,md}\" \"*.{js,json,ts}\" \".*.json\" \".prettierrc\""
   },
   "dependencies": {
+    "@react-three/drei": "^9.114.0",
+    "@react-three/fiber": "^8.17.0",
     "next": "^15.5.21",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "react-dropzone": "^14.2.0",
     "sonner": "^1.4.0",
+    "three": "^0.169.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
+    "@types/three": "^0.169.0",
     "autoprefixer": "^10.4.0",
     "eslint": "^9.39.5",
     "eslint-config-next": "^16.2.11",

--- a/frontend/src/app/jobs/[id]/page.tsx
+++ b/frontend/src/app/jobs/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use, useCallback, useEffect, useState } from "react";
+import dynamic from "next/dynamic";
 import Link from "next/link";
 import Card from "@/components/shared/Card";
 import ProgressTracker from "@/components/job/ProgressTracker";
@@ -8,6 +9,11 @@ import PageViewer from "@/components/job/PageViewer";
 import DownloadButton from "@/components/job/DownloadButton";
 import { getJob } from "@/lib/api";
 import type { Job } from "@/types/api";
+
+const Model3DPreview = dynamic(() => import("@/components/job/Model3DPreview"), {
+  ssr: false,
+  loading: () => <p className="text-center text-sm text-gray-600">Loading 3D preview…</p>,
+});
 
 export default function JobDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
@@ -50,8 +56,17 @@ export default function JobDetailPage({ params }: { params: Promise<{ id: string
             <PageViewer jobId={id} pageCount={job.page_count} />
           </div>
         )}
+        {job && job.status === "completed" && job.config?.mode === "3d" && (
+          <div className="mt-6">
+            <Model3DPreview jobId={id} />
+          </div>
+        )}
         <div className="mt-6">
-          <DownloadButton jobId={id} isReady={job?.status === "completed"} />
+          <DownloadButton
+            jobId={id}
+            isReady={job?.status === "completed"}
+            is3D={job?.config?.mode === "3d"}
+          />
         </div>
       </Card>
     </div>

--- a/frontend/src/components/job/DownloadButton.tsx
+++ b/frontend/src/components/job/DownloadButton.tsx
@@ -6,18 +6,28 @@ import { getJobDownloadUrl } from "@/lib/api";
 interface DownloadButtonProps {
   jobId: string;
   isReady: boolean;
+  is3D?: boolean;
 }
 
-export default function DownloadButton({ jobId, isReady }: DownloadButtonProps) {
+export default function DownloadButton({ jobId, isReady, is3D = false }: DownloadButtonProps) {
   if (!isReady) {
     return null;
   }
 
   return (
-    <a href={getJobDownloadUrl(jobId)} download className="block">
-      <Button variant="outline" className="w-full">
-        Download DXF
-      </Button>
-    </a>
+    <div className="space-y-2">
+      <a href={getJobDownloadUrl(jobId, "dxf")} download className="block">
+        <Button variant="outline" className="w-full">
+          Download DXF
+        </Button>
+      </a>
+      {is3D && (
+        <a href={getJobDownloadUrl(jobId, "glb")} download className="block">
+          <Button variant="outline" className="w-full">
+            Download 3D Model (GLB)
+          </Button>
+        </a>
+      )}
+    </div>
   );
 }

--- a/frontend/src/components/job/Model3DPreview.tsx
+++ b/frontend/src/components/job/Model3DPreview.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Suspense, useEffect, useMemo, useState } from "react";
+import { Canvas } from "@react-three/fiber";
+import { OrbitControls, Stage, useGLTF } from "@react-three/drei";
+import * as THREE from "three";
+import { getJobDownloadUrl } from "@/lib/api";
+import Button from "@/components/shared/Button";
+
+interface Model3DPreviewProps {
+  jobId: string;
+}
+
+function Model({ url, wireframe }: { url: string; wireframe: boolean }) {
+  const { scene } = useGLTF(url);
+
+  const clonedScene = useMemo(() => scene.clone(true), [scene]);
+
+  useEffect(() => {
+    clonedScene.traverse((child) => {
+      if (child instanceof THREE.Mesh) {
+        const materials = Array.isArray(child.material) ? child.material : [child.material];
+        materials.forEach((material) => {
+          if (material instanceof THREE.MeshStandardMaterial || "wireframe" in material) {
+            (material as THREE.MeshStandardMaterial).wireframe = wireframe;
+          }
+        });
+      }
+    });
+  }, [clonedScene, wireframe]);
+
+  return <primitive object={clonedScene} />;
+}
+
+export default function Model3DPreview({ jobId }: Model3DPreviewProps) {
+  const [wireframe, setWireframe] = useState(false);
+  const modelUrl = getJobDownloadUrl(jobId, "glb");
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium text-gray-700">3D Model Preview</h3>
+        <Button
+          variant="outline"
+          className="px-3 py-1 text-xs"
+          onClick={() => setWireframe((value) => !value)}
+        >
+          {wireframe ? "Solid shading" : "Wireframe"}
+        </Button>
+      </div>
+      <div className="h-96 w-full overflow-hidden rounded-lg border border-gray-200 bg-gray-900">
+        <Canvas camera={{ position: [10, 10, 10], fov: 50 }} dpr={[1, 2]}>
+          <Suspense fallback={null}>
+            <Stage environment="city" intensity={0.5} adjustCamera>
+              <Model url={modelUrl} wireframe={wireframe} />
+            </Stage>
+          </Suspense>
+          <OrbitControls enablePan enableZoom enableRotate makeDefault />
+        </Canvas>
+      </div>
+      <p className="text-center text-xs text-gray-500">
+        Drag to rotate · scroll to zoom · right-click drag to pan
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/upload/ConversionOptions.tsx
+++ b/frontend/src/components/upload/ConversionOptions.tsx
@@ -65,31 +65,63 @@ export default function ConversionOptions({
       </div>
 
       {config.mode === "3d" && (
-        <div>
-          <label className="mb-2 block text-sm font-medium text-gray-700">Floor Height (m)</label>
-          <input
-            type="number"
-            min={0.5}
-            max={10}
-            step={0.1}
-            value={config.floor_height_m}
-            onChange={(e) => onChange({ ...config, floor_height_m: Number(e.target.value) })}
-            disabled={disabled}
-            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
-          />
-        </div>
+        <>
+          <div>
+            <label className="mb-2 block text-sm font-medium text-gray-700">Floor Height (m)</label>
+            <input
+              type="number"
+              min={0.5}
+              max={10}
+              step={0.1}
+              value={config.floor_height_m}
+              onChange={(e) => onChange({ ...config, floor_height_m: Number(e.target.value) })}
+              disabled={disabled}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+            />
+          </div>
+
+          <div>
+            <label className="mb-2 block text-sm font-medium text-gray-700">
+              Slab Thickness (m)
+            </label>
+            <input
+              type="number"
+              min={0.05}
+              max={2}
+              step={0.05}
+              value={config.slab_thickness_m ?? 0.2}
+              onChange={(e) => onChange({ ...config, slab_thickness_m: Number(e.target.value) })}
+              disabled={disabled}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+            />
+          </div>
+
+          <label className="flex items-center gap-2 text-sm font-medium text-gray-700">
+            <input
+              type="checkbox"
+              checked={config.include_ceiling ?? false}
+              onChange={(e) => onChange({ ...config, include_ceiling: e.target.checked })}
+              disabled={disabled}
+              className="h-4 w-4 accent-primary"
+            />
+            Add ceiling slab at floor height
+          </label>
+        </>
       )}
 
       <div>
         <label className="mb-2 block text-sm font-medium text-gray-700">Output Format</label>
         <select
           value={config.output_format}
-          onChange={(e) => onChange({ ...config, output_format: e.target.value as "dxf" | "dwg" })}
+          onChange={(e) =>
+            onChange({ ...config, output_format: e.target.value as "dxf" | "dwg" | "glb" })
+          }
           disabled={disabled}
           className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
         >
           <option value="dxf">DXF</option>
           <option value="dwg">DWG</option>
+          {config.mode === "3d" && <option value="glb">GLB (3D model)</option>}
         </select>
       </div>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,16 +1,8 @@
-import type { Job, JobCreateResponse, JobListResponse } from "@/types/api";
+import type { Job, JobConfig, JobCreateResponse, JobListResponse } from "@/types/api";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "";
 
-export async function uploadFile(
-  file: File,
-  config: {
-    mode: "2d" | "3d";
-    dpi: number;
-    floor_height_m: number;
-    output_format: "dxf" | "dwg";
-  }
-): Promise<JobCreateResponse> {
+export async function uploadFile(file: File, config: JobConfig): Promise<JobCreateResponse> {
   const formData = new FormData();
   formData.append("file", file);
   formData.append("config", JSON.stringify(config));
@@ -32,8 +24,8 @@ export function getPageImageUrl(jobId: string, pageNumber: number): string {
   return `${API_BASE}/api/v1/jobs/${jobId}/pages/${pageNumber}`;
 }
 
-export function getJobDownloadUrl(jobId: string): string {
-  return `${API_BASE}/api/v1/jobs/${jobId}/download`;
+export function getJobDownloadUrl(jobId: string, format: "dxf" | "glb" = "dxf"): string {
+  return `${API_BASE}/api/v1/jobs/${jobId}/download?format=${format}`;
 }
 
 export async function getJob(jobId: string): Promise<Job> {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -4,7 +4,9 @@ export interface JobConfig {
   mode: "2d" | "3d";
   dpi: number;
   floor_height_m: number;
-  output_format: "dxf" | "dwg";
+  slab_thickness_m?: number;
+  include_ceiling?: boolean;
+  output_format: "dxf" | "dwg" | "glb";
   segmenter: "ml" | "classic";
 }
 


### PR DESCRIPTION
Completed Stage 4 / Phase 4: 3D Extrusion and pushed it to GitHub without creating a PR.

Commit chunks:
- `ffd96aa feat(backend): extrude walls and slabs into 3d`
- `cf53876 feat(backend): export 3d dxf and glb models`
- `284cbdb feat(frontend): add 3d model preview and glb download`
- `b20233e docs: document stage 4 3d extrusion`
- `706beb8 chore: update talisman checksums`


Backend quality gates passed:
- `ruff check .` passed
- `ruff format --check .` passed
- `mypy app/` passed
- `pytest -q` passed: `54 passed, 5 warnings`

Frontend quality gates passed:
- `npm run lint` passed
- `npm run format:check` passed
- `npm run build` passed

Updated files include:
- Backend 3D primitives/extrusion/export pipeline files
- Backend tests for extrusion, GLB output, DXF output, and downloads
- Frontend 3D preview/download UI and API types
- `TODO.md`
- `README.md`
- `.talismanrc`

Closes #21, #22, #23, #24   