### PR TITLE
Feature/make service management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,7 @@ backend/app/**/*.pyc
 
 # Logs
 logs/
+.make/
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/.talismanrc
+++ b/.talismanrc
@@ -29,4 +29,6 @@ fileignoreconfig:
   checksum: 2962c6ac1f8fd80de3734e1998bea00860455a099cba242d227d78378e538c7b
 - filename: frontend/src/components/history/JobTable.tsx
   checksum: ea9ed540884f893a02d0efd11f9787cece503ad543a09724f9c67b17c3817ed0
+- filename: backend/tests/test_placeholder_task_paths.py
+  checksum: 9d4d13e1fb42553059aa323251d2b7e31f89c2c653a8fabaf3de5f6e6a9dfe94
 version: "1.0"

--- a/Makefile
+++ b/Makefile
@@ -16,20 +16,14 @@ LOCAL_BACKEND_PORT ?= 8000
 LOCAL_FRONTEND_HOST ?= 0.0.0.0
 LOCAL_FRONTEND_PORT ?= 3000
 LOCAL_WAIT_SECONDS ?= 30
-CELERY_LOG_LEVEL ?= info
 
-# Local infrastructure defaults to Homebrew services on macOS.
-# Use LOCAL_INFRA=external when PostgreSQL/Redis are managed outside Make.
-LOCAL_INFRA ?= brew
-BREW_POSTGRES_SERVICE ?= postgresql@16
-BREW_REDIS_SERVICE ?= redis
-LOCAL_DB_NAME ?= aifc
-LOCAL_DB_USER ?= aifc
-LOCAL_DB_PASSWORD ?= aifc
-POSTGRES_HOST ?= localhost
-POSTGRES_PORT ?= 5432
-REDIS_HOST ?= localhost
-REDIS_PORT ?= 6379
+# Hybrid local development runs frontend/backend on the host, while PostgreSQL,
+# Redis, worker, and optional Beat run in Docker. The host backend and Docker
+# worker must share storage/model directories so queued jobs can read the same
+# files regardless of which process created them.
+LOCAL_STORAGE_DIR ?= ./backend/storage
+LOCAL_MODELS_DIR ?= ./backend/models
+LOCAL_DOCKER_ENV := STORAGE_VOLUME=$(LOCAL_STORAGE_DIR) MODELS_VOLUME=$(LOCAL_MODELS_DIR) STORAGE_PATH=storage MODELS_PATH=models
 
 .PHONY: help
 help: ## Show available Make targets
@@ -37,31 +31,33 @@ help: ## Show available Make targets
 	@printf "\nSpecific Docker service targets:\n"
 	@printf "  \033[36m%-28s\033[0m %s\n" "docker-up-postgres" "Start PostgreSQL with Docker" "docker-up-redis" "Start Redis with Docker" "docker-up-backend" "Start FastAPI with Docker" "docker-up-worker" "Start Celery worker with Docker" "docker-up-beat" "Start Celery Beat with Docker" "docker-up-frontend" "Start Next.js with Docker"
 	@printf "  \033[36m%-28s\033[0m %s\n" "docker-stop-postgres" "Stop PostgreSQL Docker service" "docker-stop-redis" "Stop Redis Docker service" "docker-stop-backend" "Stop FastAPI Docker service" "docker-stop-worker" "Stop Celery worker Docker service" "docker-stop-beat" "Stop Celery Beat Docker service" "docker-stop-frontend" "Stop Next.js Docker service"
-	@printf "\nCommon variables:\n  COMPOSE=%s\n  LOCAL_INFRA=%s (brew|external)\n  BACKEND_VENV=%s\n\n" "$(COMPOSE)" "$(LOCAL_INFRA)" "$(BACKEND_VENV)"
+	@printf "\nHybrid local development:\n"
+	@printf "  \033[36m%-28s\033[0m %s\n" "local-up" "Host frontend/backend + Docker postgres/redis/worker" "local-down" "Stop host frontend/backend + Docker local services" "local-up-beat" "Optionally start cleanup scheduler in Docker"
+	@printf "\nCommon variables:\n  COMPOSE=%s\n  BACKEND_VENV=%s\n  LOCAL_STORAGE_DIR=%s\n  LOCAL_MODELS_DIR=%s\n\n" "$(COMPOSE)" "$(BACKEND_VENV)" "$(LOCAL_STORAGE_DIR)" "$(LOCAL_MODELS_DIR)"
 
-define start_local_service
+define start_host_service
 	@mkdir -p "$(PID_DIR)" "$(LOG_DIR)"
 	@if [ -f "$(PID_DIR)/$(1).pid" ] && kill -0 "$$(cat "$(PID_DIR)/$(1).pid")" 2>/dev/null; then \
-		echo "$(1) already running (pid $$(cat "$(PID_DIR)/$(1).pid"))"; \
+		echo "$(1) already running on the host (pid $$(cat "$(PID_DIR)/$(1).pid"))"; \
 	else \
-		echo "Starting $(1)..."; \
+		echo "Starting $(1) on the host..."; \
 		nohup $(SHELL) -lc '$(2)' > "$(LOG_DIR)/$(1).log" 2>&1 & echo $$! > "$(PID_DIR)/$(1).pid"; \
 		echo "$(1) started (pid $$(cat "$(PID_DIR)/$(1).pid"), log $(LOG_DIR)/$(1).log)"; \
 	fi
 endef
 
-define stop_local_service
+define stop_host_service
 	@if [ -f "$(PID_DIR)/$(1).pid" ]; then \
 		PID="$$(cat "$(PID_DIR)/$(1).pid")"; \
 		if kill -0 "$$PID" 2>/dev/null; then \
-			echo "Stopping $(1) (pid $$PID)..."; \
+			echo "Stopping host $(1) (pid $$PID)..."; \
 			kill "$$PID" 2>/dev/null || true; \
 			for _ in $$(seq 1 10); do \
 				kill -0 "$$PID" 2>/dev/null || break; \
 				sleep 1; \
 			done; \
 			if kill -0 "$$PID" 2>/dev/null; then \
-				echo "Force stopping $(1) (pid $$PID)..."; \
+				echo "Force stopping host $(1) (pid $$PID)..."; \
 				kill -9 "$$PID" 2>/dev/null || true; \
 			fi; \
 		else \
@@ -69,7 +65,7 @@ define stop_local_service
 		fi; \
 		rm -f "$(PID_DIR)/$(1).pid"; \
 	else \
-		echo "$(1) is not running"; \
+		echo "host $(1) is not running"; \
 	fi
 endef
 
@@ -93,16 +89,9 @@ check-compose:
 		exit 1; \
 	fi
 
-.PHONY: check-brew
-check-brew:
-	@if [ "$(LOCAL_INFRA)" = "brew" ] && ! command -v brew >/dev/null 2>&1; then \
-		echo "Homebrew is required for LOCAL_INFRA=brew. Install brew or run with LOCAL_INFRA=external after starting PostgreSQL/Redis yourself."; \
-		exit 1; \
-	fi
-
 .PHONY: check-backend-venv
 check-backend-venv:
-	@if [ ! -x "$(BACKEND_BIN)/uvicorn" ] || [ ! -x "$(BACKEND_BIN)/celery" ] || [ ! -x "$(BACKEND_BIN)/alembic" ]; then \
+	@if [ ! -x "$(BACKEND_BIN)/uvicorn" ] || [ ! -x "$(BACKEND_BIN)/alembic" ]; then \
 		echo "Backend virtualenv is missing required commands under $(BACKEND_VENV)."; \
 		echo "Run: cd backend && python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt"; \
 		exit 1; \
@@ -115,9 +104,17 @@ check-frontend-deps:
 		exit 1; \
 	fi
 
-.PHONY: docker-up docker-down docker-restart docker-build docker-ps docker-logs docker-migrate docker-up-dwg
+.PHONY: prepare-local-docker
+prepare-local-docker:
+	mkdir -p "$(LOCAL_STORAGE_DIR)" "$(LOCAL_MODELS_DIR)"
+
+.PHONY: docker-up docker-up-dev docker-up-prod docker-down docker-restart docker-build docker-ps docker-logs docker-migrate docker-up-dwg
 docker-up: check-compose ## Start all Docker services (frontend, backend, worker, beat, postgres, redis)
 	$(COMPOSE) up -d --build $(DOCKER_SERVICES)
+
+docker-up-dev: docker-up ## Alias for all-Docker local development/test startup
+
+docker-up-prod: docker-up ## Alias for all-Docker production-like startup
 
 docker-down: check-compose ## Stop and remove all Docker services
 	$(COMPOSE) down
@@ -155,119 +152,87 @@ docker-stop-service: check-compose ## Stop one Docker service with SERVICE=<name
 	@test -n "$(SERVICE)" || (echo "Usage: make docker-stop-service SERVICE=backend" && exit 1)
 	$(COMPOSE) stop $(SERVICE)
 
-.PHONY: local-up local-down local-restart local-status local-db-setup local-migrate local-logs
-local-up: local-up-postgres local-db-setup local-up-redis local-migrate local-up-backend local-up-worker local-up-beat local-up-frontend ## Start all services without Docker (Homebrew infra + local app processes)
-	@echo "Local stack started. Frontend: http://localhost:$(LOCAL_FRONTEND_PORT) Backend: http://localhost:$(LOCAL_BACKEND_PORT)/api/v1/health"
+.PHONY: local-up local-down local-restart local-status local-migrate local-logs
+local-up: local-up-postgres local-up-redis local-migrate local-up-worker local-up-backend local-up-frontend ## Start hybrid local dev: host frontend/backend + Docker postgres/redis/worker
+	@echo "Hybrid local stack started. Frontend: http://localhost:$(LOCAL_FRONTEND_PORT) Backend: http://localhost:$(LOCAL_BACKEND_PORT)/api/v1/health"
 
-local-down: local-down-frontend local-down-beat local-down-worker local-down-backend local-down-redis local-down-postgres ## Stop all non-Docker services started by Make
-	@echo "Local stack stopped."
+local-down: local-down-frontend local-down-backend local-down-beat local-down-worker local-down-redis local-down-postgres ## Stop hybrid local dev services
+	@echo "Hybrid local stack stopped."
 
-local-restart: local-down local-up ## Restart all non-Docker services
+local-restart: local-down local-up ## Restart hybrid local dev services
 
-local-status: ## Show local PID-managed service status and infrastructure ports
+local-status: check-compose ## Show host frontend/backend and Docker local service status
 	@mkdir -p "$(PID_DIR)"
-	@for service in backend worker beat frontend; do \
+	@for service in backend frontend; do \
 		if [ -f "$(PID_DIR)/$$service.pid" ] && kill -0 "$$(cat "$(PID_DIR)/$$service.pid")" 2>/dev/null; then \
-			echo "$$service: running (pid $$(cat "$(PID_DIR)/$$service.pid"))"; \
+			echo "host $$service: running (pid $$(cat "$(PID_DIR)/$$service.pid"))"; \
 		else \
-			echo "$$service: stopped"; \
+			echo "host $$service: stopped"; \
 		fi; \
 	done
-	@nc -z "$(POSTGRES_HOST)" "$(POSTGRES_PORT)" >/dev/null 2>&1 && echo "postgres: reachable on $(POSTGRES_HOST):$(POSTGRES_PORT)" || echo "postgres: not reachable on $(POSTGRES_HOST):$(POSTGRES_PORT)"
-	@nc -z "$(REDIS_HOST)" "$(REDIS_PORT)" >/dev/null 2>&1 && echo "redis: reachable on $(REDIS_HOST):$(REDIS_PORT)" || echo "redis: not reachable on $(REDIS_HOST):$(REDIS_PORT)"
+	$(LOCAL_DOCKER_ENV) $(COMPOSE) ps postgres redis worker beat
 
-local-db-setup: ## Create the local PostgreSQL role/database expected by .env
-	@if [ "$(LOCAL_INFRA)" = "external" ]; then \
-		echo "LOCAL_INFRA=external: skipping PostgreSQL role/database setup"; \
-	elif ! command -v psql >/dev/null 2>&1; then \
-		echo "psql is unavailable; install PostgreSQL client tools or create role/database manually"; \
-		exit 1; \
-	else \
-		if ! psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='$(LOCAL_DB_USER)'" | grep -q 1; then \
-			echo "Creating PostgreSQL role $(LOCAL_DB_USER)..."; \
-			psql postgres -v ON_ERROR_STOP=1 -c "CREATE ROLE $(LOCAL_DB_USER) LOGIN PASSWORD '$(LOCAL_DB_PASSWORD)'"; \
-		fi; \
-		if ! psql postgres -tAc "SELECT 1 FROM pg_database WHERE datname='$(LOCAL_DB_NAME)'" | grep -q 1; then \
-			echo "Creating PostgreSQL database $(LOCAL_DB_NAME)..."; \
-			createdb -O "$(LOCAL_DB_USER)" "$(LOCAL_DB_NAME)"; \
-		fi; \
-	fi
-
-local-migrate: check-backend-venv ## Run Alembic migrations without Docker
+local-migrate: check-backend-venv ## Run Alembic migrations from the host backend against Docker PostgreSQL
 	cd backend && "$(BACKEND_BIN)/alembic" upgrade head
 
-local-logs: ## Follow all local app logs created by Make
+local-logs: ## Follow host backend/frontend logs created by Make
 	@mkdir -p "$(LOG_DIR)"
 	tail -n 100 -f "$(LOG_DIR)"/*.log
 
-.PHONY: local-up-postgres local-up-redis local-down-postgres local-down-redis
-local-up-postgres: check-brew ## Start local PostgreSQL without Docker (Homebrew by default)
-	@if [ "$(LOCAL_INFRA)" = "external" ]; then \
-		echo "LOCAL_INFRA=external: assuming PostgreSQL is managed outside Make"; \
-	else \
-		brew services start "$(BREW_POSTGRES_SERVICE)"; \
-	fi
-	$(call wait_port,PostgreSQL,$(POSTGRES_HOST),$(POSTGRES_PORT))
+.PHONY: local-up-postgres local-up-redis local-up-worker local-up-beat local-down-postgres local-down-redis local-down-worker local-down-beat
+local-up-postgres: check-compose prepare-local-docker ## Start local-dev PostgreSQL in Docker
+	$(LOCAL_DOCKER_ENV) $(COMPOSE) up -d postgres
+	$(call wait_port,PostgreSQL,localhost,5432)
 
-local-up-redis: check-brew ## Start local Redis without Docker (Homebrew by default)
-	@if [ "$(LOCAL_INFRA)" = "external" ]; then \
-		echo "LOCAL_INFRA=external: assuming Redis is managed outside Make"; \
-	else \
-		brew services start "$(BREW_REDIS_SERVICE)"; \
-	fi
-	$(call wait_port,Redis,$(REDIS_HOST),$(REDIS_PORT))
+local-up-redis: check-compose prepare-local-docker ## Start local-dev Redis in Docker
+	$(LOCAL_DOCKER_ENV) $(COMPOSE) up -d redis
+	$(call wait_port,Redis,localhost,6379)
 
-local-down-postgres: check-brew ## Stop local PostgreSQL if LOCAL_INFRA=brew
-	@if [ "$(LOCAL_INFRA)" = "external" ]; then \
-		echo "LOCAL_INFRA=external: leaving PostgreSQL untouched"; \
-	else \
-		brew services stop "$(BREW_POSTGRES_SERVICE)" || true; \
-	fi
+local-up-worker: check-compose prepare-local-docker ## Start local-dev Celery worker in Docker
+	$(LOCAL_DOCKER_ENV) $(COMPOSE) up -d --build worker
 
-local-down-redis: check-brew ## Stop local Redis if LOCAL_INFRA=brew
-	@if [ "$(LOCAL_INFRA)" = "external" ]; then \
-		echo "LOCAL_INFRA=external: leaving Redis untouched"; \
-	else \
-		brew services stop "$(BREW_REDIS_SERVICE)" || true; \
-	fi
+local-up-beat: check-compose prepare-local-docker ## Optionally start local-dev Celery Beat in Docker
+	$(LOCAL_DOCKER_ENV) $(COMPOSE) up -d --build beat
 
-.PHONY: local-up-backend local-up-worker local-up-beat local-up-frontend
-local-up-backend: check-backend-venv ## Start FastAPI without Docker in the background
-	$(call start_local_service,backend,cd backend && "$(BACKEND_BIN)/uvicorn" app.main:app --reload --host "$(LOCAL_BACKEND_HOST)" --port "$(LOCAL_BACKEND_PORT)")
+local-down-postgres: check-compose ## Stop local-dev Docker PostgreSQL
+	$(LOCAL_DOCKER_ENV) $(COMPOSE) stop postgres
 
-local-up-worker: check-backend-venv ## Start Celery worker without Docker in the background
-	$(call start_local_service,worker,cd backend && "$(BACKEND_BIN)/celery" -A app.tasks.celery_app worker --loglevel="$(CELERY_LOG_LEVEL)")
+local-down-redis: check-compose ## Stop local-dev Docker Redis
+	$(LOCAL_DOCKER_ENV) $(COMPOSE) stop redis
 
-local-up-beat: check-backend-venv ## Start Celery Beat without Docker in the background
-	$(call start_local_service,beat,cd backend && "$(BACKEND_BIN)/celery" -A app.tasks.celery_app beat --loglevel="$(CELERY_LOG_LEVEL)")
+local-down-worker: check-compose ## Stop local-dev Docker worker
+	$(LOCAL_DOCKER_ENV) $(COMPOSE) stop worker
 
-local-up-frontend: check-frontend-deps ## Start Next.js without Docker in the background
-	$(call start_local_service,frontend,cd frontend && npm run dev -- --hostname "$(LOCAL_FRONTEND_HOST)" --port "$(LOCAL_FRONTEND_PORT)")
+local-down-beat: check-compose ## Stop local-dev Docker Beat if running
+	$(LOCAL_DOCKER_ENV) $(COMPOSE) stop beat || true
 
-.PHONY: local-down-backend local-down-worker local-down-beat local-down-frontend
-local-down-backend: ## Stop local FastAPI process started by Make
-	$(call stop_local_service,backend)
+.PHONY: local-up-backend local-up-frontend local-down-backend local-down-frontend
+local-up-backend: check-backend-venv prepare-local-docker ## Start FastAPI on the host
+	$(call start_host_service,backend,cd backend && "$(BACKEND_BIN)/uvicorn" app.main:app --reload --host "$(LOCAL_BACKEND_HOST)" --port "$(LOCAL_BACKEND_PORT)")
 
-local-down-worker: ## Stop local Celery worker process started by Make
-	$(call stop_local_service,worker)
+local-up-frontend: check-frontend-deps ## Start Next.js on the host
+	$(call start_host_service,frontend,cd frontend && npm run dev -- --hostname "$(LOCAL_FRONTEND_HOST)" --port "$(LOCAL_FRONTEND_PORT)")
 
-local-down-beat: ## Stop local Celery Beat process started by Make
-	$(call stop_local_service,beat)
+local-down-backend: ## Stop host FastAPI process started by Make
+	$(call stop_host_service,backend)
 
-local-down-frontend: ## Stop local Next.js process started by Make
-	$(call stop_local_service,frontend)
+local-down-frontend: ## Stop host Next.js process started by Make
+	$(call stop_host_service,frontend)
 
-.PHONY: logs-backend logs-worker logs-beat logs-frontend clean-local-runtime
-logs-backend logs-worker logs-beat logs-frontend: ## Follow one local service log (target suffix selects service)
+.PHONY: logs-backend logs-frontend logs-worker logs-beat clean-local-runtime
+logs-backend logs-frontend: ## Follow one host service log (target suffix selects service)
 	@mkdir -p "$(LOG_DIR)"
 	tail -n 100 -f "$(LOG_DIR)/$(subst logs-,,$@).log"
 
-clean-local-runtime: ## Remove local Make PID/log runtime files
+logs-worker logs-beat: check-compose ## Follow one Docker service log (target suffix selects service)
+	$(LOCAL_DOCKER_ENV) $(COMPOSE) logs -f --tail=100 $(subst logs-,,$@)
+
+clean-local-runtime: ## Remove host Make PID/log runtime files
 	rm -rf "$(PID_DIR)" "$(LOG_DIR)"
 
 .PHONY: up down restart
-up: local-up ## Alias: start all services without Docker
+up: local-up ## Alias: start hybrid local dev services
 
-down: local-down ## Alias: stop all services without Docker
+down: local-down ## Alias: stop hybrid local dev services
 
-restart: local-restart ## Alias: restart all services without Docker
+restart: local-restart ## Alias: restart hybrid local dev services

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,273 @@
+.DEFAULT_GOAL := help
+SHELL := /bin/bash
+
+# Docker Compose command is auto-detected, but can be overridden:
+#   make docker-up COMPOSE="docker-compose"
+COMPOSE ?= $(shell if docker compose version >/dev/null 2>&1; then printf 'docker compose'; elif command -v docker-compose >/dev/null 2>&1; then printf 'docker-compose'; else printf 'docker compose'; fi)
+
+DOCKER_SERVICES := postgres redis backend worker beat frontend
+
+PID_DIR ?= .make/pids
+LOG_DIR ?= .make/logs
+BACKEND_VENV ?= backend/.venv
+BACKEND_BIN := $(CURDIR)/$(BACKEND_VENV)/bin
+LOCAL_BACKEND_HOST ?= 0.0.0.0
+LOCAL_BACKEND_PORT ?= 8000
+LOCAL_FRONTEND_HOST ?= 0.0.0.0
+LOCAL_FRONTEND_PORT ?= 3000
+LOCAL_WAIT_SECONDS ?= 30
+CELERY_LOG_LEVEL ?= info
+
+# Local infrastructure defaults to Homebrew services on macOS.
+# Use LOCAL_INFRA=external when PostgreSQL/Redis are managed outside Make.
+LOCAL_INFRA ?= brew
+BREW_POSTGRES_SERVICE ?= postgresql@16
+BREW_REDIS_SERVICE ?= redis
+LOCAL_DB_NAME ?= aifc
+LOCAL_DB_USER ?= aifc
+LOCAL_DB_PASSWORD ?= aifc
+POSTGRES_HOST ?= localhost
+POSTGRES_PORT ?= 5432
+REDIS_HOST ?= localhost
+REDIS_PORT ?= 6379
+
+.PHONY: help
+help: ## Show available Make targets
+	@awk 'BEGIN {FS = ":.*##"; printf "\nDrawLift service management\n\nUsage:\n  make <target> [VARIABLE=value]\n\nTargets:\n"} /^[a-zA-Z0-9_.-]+:.*##/ {printf "  \033[36m%-28s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@printf "\nSpecific Docker service targets:\n"
+	@printf "  \033[36m%-28s\033[0m %s\n" "docker-up-postgres" "Start PostgreSQL with Docker" "docker-up-redis" "Start Redis with Docker" "docker-up-backend" "Start FastAPI with Docker" "docker-up-worker" "Start Celery worker with Docker" "docker-up-beat" "Start Celery Beat with Docker" "docker-up-frontend" "Start Next.js with Docker"
+	@printf "  \033[36m%-28s\033[0m %s\n" "docker-stop-postgres" "Stop PostgreSQL Docker service" "docker-stop-redis" "Stop Redis Docker service" "docker-stop-backend" "Stop FastAPI Docker service" "docker-stop-worker" "Stop Celery worker Docker service" "docker-stop-beat" "Stop Celery Beat Docker service" "docker-stop-frontend" "Stop Next.js Docker service"
+	@printf "\nCommon variables:\n  COMPOSE=%s\n  LOCAL_INFRA=%s (brew|external)\n  BACKEND_VENV=%s\n\n" "$(COMPOSE)" "$(LOCAL_INFRA)" "$(BACKEND_VENV)"
+
+define start_local_service
+	@mkdir -p "$(PID_DIR)" "$(LOG_DIR)"
+	@if [ -f "$(PID_DIR)/$(1).pid" ] && kill -0 "$$(cat "$(PID_DIR)/$(1).pid")" 2>/dev/null; then \
+		echo "$(1) already running (pid $$(cat "$(PID_DIR)/$(1).pid"))"; \
+	else \
+		echo "Starting $(1)..."; \
+		nohup $(SHELL) -lc '$(2)' > "$(LOG_DIR)/$(1).log" 2>&1 & echo $$! > "$(PID_DIR)/$(1).pid"; \
+		echo "$(1) started (pid $$(cat "$(PID_DIR)/$(1).pid"), log $(LOG_DIR)/$(1).log)"; \
+	fi
+endef
+
+define stop_local_service
+	@if [ -f "$(PID_DIR)/$(1).pid" ]; then \
+		PID="$$(cat "$(PID_DIR)/$(1).pid")"; \
+		if kill -0 "$$PID" 2>/dev/null; then \
+			echo "Stopping $(1) (pid $$PID)..."; \
+			kill "$$PID" 2>/dev/null || true; \
+			for _ in $$(seq 1 10); do \
+				kill -0 "$$PID" 2>/dev/null || break; \
+				sleep 1; \
+			done; \
+			if kill -0 "$$PID" 2>/dev/null; then \
+				echo "Force stopping $(1) (pid $$PID)..."; \
+				kill -9 "$$PID" 2>/dev/null || true; \
+			fi; \
+		else \
+			echo "$(1) pid file exists, but process $$PID is not running"; \
+		fi; \
+		rm -f "$(PID_DIR)/$(1).pid"; \
+	else \
+		echo "$(1) is not running"; \
+	fi
+endef
+
+define wait_port
+	@echo "Waiting for $(1) on $(2):$(3)..."
+	@for _ in $$(seq 1 $(LOCAL_WAIT_SECONDS)); do \
+		if nc -z "$(2)" "$(3)" >/dev/null 2>&1; then \
+			echo "$(1) is reachable"; \
+			exit 0; \
+		fi; \
+		sleep 1; \
+	done; \
+	echo "$(1) did not become reachable on $(2):$(3) within $(LOCAL_WAIT_SECONDS)s"; \
+	exit 1
+endef
+
+.PHONY: check-compose
+check-compose:
+	@if ! $(COMPOSE) version >/dev/null 2>&1; then \
+		echo "Docker Compose is unavailable. Install Docker Compose or override COMPOSE, e.g. make docker-up COMPOSE=docker-compose"; \
+		exit 1; \
+	fi
+
+.PHONY: check-brew
+check-brew:
+	@if [ "$(LOCAL_INFRA)" = "brew" ] && ! command -v brew >/dev/null 2>&1; then \
+		echo "Homebrew is required for LOCAL_INFRA=brew. Install brew or run with LOCAL_INFRA=external after starting PostgreSQL/Redis yourself."; \
+		exit 1; \
+	fi
+
+.PHONY: check-backend-venv
+check-backend-venv:
+	@if [ ! -x "$(BACKEND_BIN)/uvicorn" ] || [ ! -x "$(BACKEND_BIN)/celery" ] || [ ! -x "$(BACKEND_BIN)/alembic" ]; then \
+		echo "Backend virtualenv is missing required commands under $(BACKEND_VENV)."; \
+		echo "Run: cd backend && python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt"; \
+		exit 1; \
+	fi
+
+.PHONY: check-frontend-deps
+check-frontend-deps:
+	@if [ ! -d "frontend/node_modules" ]; then \
+		echo "Frontend dependencies are missing. Run: cd frontend && npm install"; \
+		exit 1; \
+	fi
+
+.PHONY: docker-up docker-down docker-restart docker-build docker-ps docker-logs docker-migrate docker-up-dwg
+docker-up: check-compose ## Start all Docker services (frontend, backend, worker, beat, postgres, redis)
+	$(COMPOSE) up -d --build $(DOCKER_SERVICES)
+
+docker-down: check-compose ## Stop and remove all Docker services
+	$(COMPOSE) down
+
+docker-restart: docker-down docker-up ## Restart all Docker services
+
+docker-build: check-compose ## Build Docker service images
+	$(COMPOSE) build $(DOCKER_SERVICES)
+
+docker-ps: check-compose ## Show Docker service status
+	$(COMPOSE) ps
+
+docker-logs: check-compose ## Follow logs for all Docker services
+	$(COMPOSE) logs -f --tail=100
+
+docker-migrate: check-compose ## Run Alembic migrations in the Docker backend service
+	$(COMPOSE) exec backend alembic upgrade head
+
+docker-up-dwg: check-compose ## Start default Docker services plus the optional DWG converter profile
+	$(COMPOSE) --profile dwg up -d --build $(DOCKER_SERVICES) dwg-converter
+
+.PHONY: docker-up-postgres docker-up-redis docker-up-backend docker-up-worker docker-up-beat docker-up-frontend docker-up-service
+docker-up-postgres docker-up-redis docker-up-backend docker-up-worker docker-up-beat docker-up-frontend: check-compose ## Start one Docker service (target suffix selects service)
+	$(COMPOSE) up -d --build $(subst docker-up-,,$@)
+
+docker-up-service: check-compose ## Start one Docker service with SERVICE=<name>
+	@test -n "$(SERVICE)" || (echo "Usage: make docker-up-service SERVICE=backend" && exit 1)
+	$(COMPOSE) up -d --build $(SERVICE)
+
+.PHONY: docker-stop-postgres docker-stop-redis docker-stop-backend docker-stop-worker docker-stop-beat docker-stop-frontend docker-stop-service
+docker-stop-postgres docker-stop-redis docker-stop-backend docker-stop-worker docker-stop-beat docker-stop-frontend: check-compose ## Stop one Docker service (target suffix selects service)
+	$(COMPOSE) stop $(subst docker-stop-,,$@)
+
+docker-stop-service: check-compose ## Stop one Docker service with SERVICE=<name>
+	@test -n "$(SERVICE)" || (echo "Usage: make docker-stop-service SERVICE=backend" && exit 1)
+	$(COMPOSE) stop $(SERVICE)
+
+.PHONY: local-up local-down local-restart local-status local-db-setup local-migrate local-logs
+local-up: local-up-postgres local-db-setup local-up-redis local-migrate local-up-backend local-up-worker local-up-beat local-up-frontend ## Start all services without Docker (Homebrew infra + local app processes)
+	@echo "Local stack started. Frontend: http://localhost:$(LOCAL_FRONTEND_PORT) Backend: http://localhost:$(LOCAL_BACKEND_PORT)/api/v1/health"
+
+local-down: local-down-frontend local-down-beat local-down-worker local-down-backend local-down-redis local-down-postgres ## Stop all non-Docker services started by Make
+	@echo "Local stack stopped."
+
+local-restart: local-down local-up ## Restart all non-Docker services
+
+local-status: ## Show local PID-managed service status and infrastructure ports
+	@mkdir -p "$(PID_DIR)"
+	@for service in backend worker beat frontend; do \
+		if [ -f "$(PID_DIR)/$$service.pid" ] && kill -0 "$$(cat "$(PID_DIR)/$$service.pid")" 2>/dev/null; then \
+			echo "$$service: running (pid $$(cat "$(PID_DIR)/$$service.pid"))"; \
+		else \
+			echo "$$service: stopped"; \
+		fi; \
+	done
+	@nc -z "$(POSTGRES_HOST)" "$(POSTGRES_PORT)" >/dev/null 2>&1 && echo "postgres: reachable on $(POSTGRES_HOST):$(POSTGRES_PORT)" || echo "postgres: not reachable on $(POSTGRES_HOST):$(POSTGRES_PORT)"
+	@nc -z "$(REDIS_HOST)" "$(REDIS_PORT)" >/dev/null 2>&1 && echo "redis: reachable on $(REDIS_HOST):$(REDIS_PORT)" || echo "redis: not reachable on $(REDIS_HOST):$(REDIS_PORT)"
+
+local-db-setup: ## Create the local PostgreSQL role/database expected by .env
+	@if [ "$(LOCAL_INFRA)" = "external" ]; then \
+		echo "LOCAL_INFRA=external: skipping PostgreSQL role/database setup"; \
+	elif ! command -v psql >/dev/null 2>&1; then \
+		echo "psql is unavailable; install PostgreSQL client tools or create role/database manually"; \
+		exit 1; \
+	else \
+		if ! psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='$(LOCAL_DB_USER)'" | grep -q 1; then \
+			echo "Creating PostgreSQL role $(LOCAL_DB_USER)..."; \
+			psql postgres -v ON_ERROR_STOP=1 -c "CREATE ROLE $(LOCAL_DB_USER) LOGIN PASSWORD '$(LOCAL_DB_PASSWORD)'"; \
+		fi; \
+		if ! psql postgres -tAc "SELECT 1 FROM pg_database WHERE datname='$(LOCAL_DB_NAME)'" | grep -q 1; then \
+			echo "Creating PostgreSQL database $(LOCAL_DB_NAME)..."; \
+			createdb -O "$(LOCAL_DB_USER)" "$(LOCAL_DB_NAME)"; \
+		fi; \
+	fi
+
+local-migrate: check-backend-venv ## Run Alembic migrations without Docker
+	cd backend && "$(BACKEND_BIN)/alembic" upgrade head
+
+local-logs: ## Follow all local app logs created by Make
+	@mkdir -p "$(LOG_DIR)"
+	tail -n 100 -f "$(LOG_DIR)"/*.log
+
+.PHONY: local-up-postgres local-up-redis local-down-postgres local-down-redis
+local-up-postgres: check-brew ## Start local PostgreSQL without Docker (Homebrew by default)
+	@if [ "$(LOCAL_INFRA)" = "external" ]; then \
+		echo "LOCAL_INFRA=external: assuming PostgreSQL is managed outside Make"; \
+	else \
+		brew services start "$(BREW_POSTGRES_SERVICE)"; \
+	fi
+	$(call wait_port,PostgreSQL,$(POSTGRES_HOST),$(POSTGRES_PORT))
+
+local-up-redis: check-brew ## Start local Redis without Docker (Homebrew by default)
+	@if [ "$(LOCAL_INFRA)" = "external" ]; then \
+		echo "LOCAL_INFRA=external: assuming Redis is managed outside Make"; \
+	else \
+		brew services start "$(BREW_REDIS_SERVICE)"; \
+	fi
+	$(call wait_port,Redis,$(REDIS_HOST),$(REDIS_PORT))
+
+local-down-postgres: check-brew ## Stop local PostgreSQL if LOCAL_INFRA=brew
+	@if [ "$(LOCAL_INFRA)" = "external" ]; then \
+		echo "LOCAL_INFRA=external: leaving PostgreSQL untouched"; \
+	else \
+		brew services stop "$(BREW_POSTGRES_SERVICE)" || true; \
+	fi
+
+local-down-redis: check-brew ## Stop local Redis if LOCAL_INFRA=brew
+	@if [ "$(LOCAL_INFRA)" = "external" ]; then \
+		echo "LOCAL_INFRA=external: leaving Redis untouched"; \
+	else \
+		brew services stop "$(BREW_REDIS_SERVICE)" || true; \
+	fi
+
+.PHONY: local-up-backend local-up-worker local-up-beat local-up-frontend
+local-up-backend: check-backend-venv ## Start FastAPI without Docker in the background
+	$(call start_local_service,backend,cd backend && "$(BACKEND_BIN)/uvicorn" app.main:app --reload --host "$(LOCAL_BACKEND_HOST)" --port "$(LOCAL_BACKEND_PORT)")
+
+local-up-worker: check-backend-venv ## Start Celery worker without Docker in the background
+	$(call start_local_service,worker,cd backend && "$(BACKEND_BIN)/celery" -A app.tasks.celery_app worker --loglevel="$(CELERY_LOG_LEVEL)")
+
+local-up-beat: check-backend-venv ## Start Celery Beat without Docker in the background
+	$(call start_local_service,beat,cd backend && "$(BACKEND_BIN)/celery" -A app.tasks.celery_app beat --loglevel="$(CELERY_LOG_LEVEL)")
+
+local-up-frontend: check-frontend-deps ## Start Next.js without Docker in the background
+	$(call start_local_service,frontend,cd frontend && npm run dev -- --hostname "$(LOCAL_FRONTEND_HOST)" --port "$(LOCAL_FRONTEND_PORT)")
+
+.PHONY: local-down-backend local-down-worker local-down-beat local-down-frontend
+local-down-backend: ## Stop local FastAPI process started by Make
+	$(call stop_local_service,backend)
+
+local-down-worker: ## Stop local Celery worker process started by Make
+	$(call stop_local_service,worker)
+
+local-down-beat: ## Stop local Celery Beat process started by Make
+	$(call stop_local_service,beat)
+
+local-down-frontend: ## Stop local Next.js process started by Make
+	$(call stop_local_service,frontend)
+
+.PHONY: logs-backend logs-worker logs-beat logs-frontend clean-local-runtime
+logs-backend logs-worker logs-beat logs-frontend: ## Follow one local service log (target suffix selects service)
+	@mkdir -p "$(LOG_DIR)"
+	tail -n 100 -f "$(LOG_DIR)/$(subst logs-,,$@).log"
+
+clean-local-runtime: ## Remove local Make PID/log runtime files
+	rm -rf "$(PID_DIR)" "$(LOG_DIR)"
+
+.PHONY: up down restart
+up: local-up ## Alias: start all services without Docker
+
+down: local-down ## Alias: stop all services without Docker
+
+restart: local-restart ## Alias: restart all services without Docker

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ ai-file-converter/
 │
 ├── scripts/                        # GitHub bootstrap & issue creation
 ├── docker-compose.yml              # Orchestrates app services plus optional DWG converter profile
+├── Makefile                        # One-command Docker and local service management
 ├── .env.example                    # Environment variables template
 ├── .pre-commit-config.yaml         # Local lint/format/type-check hooks
 ├── .talismanrc                     # Pre-push hook config
@@ -481,21 +482,104 @@ numpy==2.*
 
 ## 12. Local Development (Quick Start)
 
-The application is fully runnable via Docker Compose:
+The root `Makefile` is the preferred entrypoint for starting and stopping the
+stack. It supports both Docker Compose and non-Docker local development, and it
+auto-detects either `docker compose` or the legacy `docker-compose` binary.
 
 ```bash
 # 1. Clone & configure
 cp .env.example .env
 
-# 2. Boot default services (frontend, backend, worker, beat, postgres, redis)
-docker compose up -d --build
+# 2A. Boot everything with Docker
+make docker-up
+make docker-migrate
 
-# 3. Run DB migrations
-docker compose exec backend alembic upgrade head
+# 2B. Or boot everything without Docker
+# Uses Homebrew services for PostgreSQL/Redis by default and PID-managed app processes.
+make local-up
 
-# 4. Open the app
+# 3. Open the app
 open http://localhost:3000      # Frontend (Next.js)
 open http://localhost:8000/api/v1/health  # Backend health check
+```
+
+### Make service management
+
+Run `make help` to list all available targets. Common all-service commands are:
+
+| Command             | Description                                                                 |
+| ------------------- | --------------------------------------------------------------------------- |
+| `make docker-up`    | Build and start frontend, backend, worker, beat, PostgreSQL, and Redis.     |
+| `make docker-down`  | Stop and remove the Docker Compose stack.                                   |
+| `make docker-up-dwg`| Start the Docker stack plus the optional DWG converter profile.             |
+| `make local-up`     | Start all services without Docker (`brew` infra + local app processes).     |
+| `make local-down`   | Stop all local processes and Homebrew-managed PostgreSQL/Redis services.    |
+| `make up`           | Alias for `make local-up`.                                                  |
+| `make down`         | Alias for `make local-down`.                                                |
+
+Service-specific Docker targets are available for each Compose service:
+
+```bash
+make docker-up-postgres
+make docker-up-redis
+make docker-up-backend
+make docker-up-worker
+make docker-up-beat
+make docker-up-frontend
+
+make docker-stop-backend
+make docker-stop-frontend
+make docker-stop-service SERVICE=redis
+```
+
+Service-specific non-Docker targets run the app services in the background and
+write PID/log files under `.make/` (ignored by Git):
+
+```bash
+make local-up-postgres       # Homebrew service by default
+make local-db-setup          # Create the local aifc role/database if missing
+make local-up-redis          # Homebrew service by default
+make local-up-backend        # FastAPI via backend/.venv
+make local-up-worker         # Celery worker via backend/.venv
+make local-up-beat           # Celery Beat via backend/.venv
+make local-up-frontend       # Next.js dev server
+
+make local-down-backend
+make local-down-worker
+make local-down-beat
+make local-down-frontend
+make local-status
+make logs-backend
+```
+
+The non-Docker workflow expects backend dependencies in `backend/.venv` and
+frontend dependencies in `frontend/node_modules`:
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+
+cd ../frontend
+npm install
+```
+
+By default, `make local-up` starts PostgreSQL and Redis via Homebrew services
+(`postgresql@16` and `redis`) and creates the expected `aifc` role/database if
+they are missing. If those services are managed separately, start them yourself
+and run:
+
+```bash
+make local-up LOCAL_INFRA=external
+```
+
+Useful overrides:
+
+```bash
+make docker-up COMPOSE=docker-compose
+make local-up BREW_POSTGRES_SERVICE=postgresql@15
+make local-up LOCAL_BACKEND_PORT=8010 LOCAL_FRONTEND_PORT=3010
 ```
 
 ### Services
@@ -517,28 +601,10 @@ Install libredwg's `dwgwrite`, mount ODA FileConverter in a sidecar/shared volum
 or set an explicit command template:
 
 ```bash
-DWG_CONVERTER_COMMAND='dwgwrite {input} {output}' docker compose up -d --build
+DWG_CONVERTER_COMMAND='dwgwrite {input} {output}' make docker-up
 ```
 
 Supported placeholders are `{input}`, `{output}`, `{input_dir}`, `{output_dir}`, and `{stem}`.
-
-### Development without Docker
-
-**Backend:**
-
-```bash
-cd backend
-pip install -r requirements.txt
-uvicorn app.main:app --reload --port 8000
-```
-
-**Frontend:**
-
-```bash
-cd frontend
-npm install
-npm run dev
-```
 
 ### Linting & Tests
 
@@ -663,4 +729,4 @@ See [TODO.md §A](./TODO.md) for the full GitHub issue management playbook, incl
 
 ---
 
-_Document version 1.0 — updated to reflect Phase 5 production polish: DWG conversion command integration, DXF/DWG/both selection, history and delete UI, failed-job retry, stored stack traces, daily cleanup, and archived jobs. Phases 1–5 implementations are in review._
+_Document version 1.0 — updated to reflect Phase 5 production polish and root Makefile service management: DWG conversion command integration, DXF/DWG/both selection, history and delete UI, failed-job retry, stored stack traces, daily cleanup, archived jobs, and one-command Docker/local startup and shutdown._

--- a/README.md
+++ b/README.md
@@ -483,19 +483,21 @@ numpy==2.*
 ## 12. Local Development (Quick Start)
 
 The root `Makefile` is the preferred entrypoint for starting and stopping the
-stack. It supports both Docker Compose and non-Docker local development, and it
-auto-detects either `docker compose` or the legacy `docker-compose` binary.
+stack. It supports both all-Docker workflows and a hybrid local development
+workflow where FastAPI/Next.js run on your machine while PostgreSQL, Redis, and
+the Celery worker run in Docker. It auto-detects either `docker compose` or the
+legacy `docker-compose` binary.
 
 ```bash
 # 1. Clone & configure
 cp .env.example .env
 
-# 2A. Boot everything with Docker
+# 2A. Boot everything with Docker (local test or production-like)
 make docker-up
 make docker-migrate
 
-# 2B. Or boot everything without Docker
-# Uses Homebrew services for PostgreSQL/Redis by default and PID-managed app processes.
+# 2B. Or use hybrid local development
+# Runs frontend/backend on the host and postgres/redis/worker in Docker.
 make local-up
 
 # 3. Open the app
@@ -507,15 +509,17 @@ open http://localhost:8000/api/v1/health  # Backend health check
 
 Run `make help` to list all available targets. Common all-service commands are:
 
-| Command             | Description                                                                 |
-| ------------------- | --------------------------------------------------------------------------- |
-| `make docker-up`    | Build and start frontend, backend, worker, beat, PostgreSQL, and Redis.     |
-| `make docker-down`  | Stop and remove the Docker Compose stack.                                   |
-| `make docker-up-dwg`| Start the Docker stack plus the optional DWG converter profile.             |
-| `make local-up`     | Start all services without Docker (`brew` infra + local app processes).     |
-| `make local-down`   | Stop all local processes and Homebrew-managed PostgreSQL/Redis services.    |
-| `make up`           | Alias for `make local-up`.                                                  |
-| `make down`         | Alias for `make local-down`.                                                |
+| Command              | Description                                                                    |
+| -------------------- | ------------------------------------------------------------------------------ |
+| `make docker-up`     | Build and start frontend, backend, worker, beat, PostgreSQL, and Redis.        |
+| `make docker-up-dev` | Alias for all-Docker local development/test startup.                           |
+| `make docker-up-prod`| Alias for all-Docker production-like startup.                                  |
+| `make docker-down`   | Stop and remove the Docker Compose stack.                                      |
+| `make docker-up-dwg` | Start the Docker stack plus the optional DWG converter profile.                |
+| `make local-up`      | Start hybrid local dev: host frontend/backend + Docker postgres/redis/worker. |
+| `make local-down`    | Stop hybrid local dev services.                                                |
+| `make up`            | Alias for `make local-up`.                                                     |
+| `make down`          | Alias for `make local-down`.                                                   |
 
 Service-specific Docker targets are available for each Compose service:
 
@@ -532,17 +536,16 @@ make docker-stop-frontend
 make docker-stop-service SERVICE=redis
 ```
 
-Service-specific non-Docker targets run the app services in the background and
-write PID/log files under `.make/` (ignored by Git):
+Hybrid local development keeps source hot-reload fast by running the app servers
+on your machine, while infrastructure and the conversion worker remain in Docker:
 
 ```bash
-make local-up-postgres       # Homebrew service by default
-make local-db-setup          # Create the local aifc role/database if missing
-make local-up-redis          # Homebrew service by default
-make local-up-backend        # FastAPI via backend/.venv
-make local-up-worker         # Celery worker via backend/.venv
-make local-up-beat           # Celery Beat via backend/.venv
-make local-up-frontend       # Next.js dev server
+make local-up-postgres       # Docker PostgreSQL
+make local-up-redis          # Docker Redis
+make local-up-worker         # Docker Celery worker
+make local-up-backend        # Host FastAPI via backend/.venv
+make local-up-frontend       # Host Next.js dev server
+make local-up-beat           # Optional Docker Celery Beat cleanup scheduler
 
 make local-down-backend
 make local-down-worker
@@ -550,10 +553,11 @@ make local-down-beat
 make local-down-frontend
 make local-status
 make logs-backend
+make logs-worker
 ```
 
-The non-Docker workflow expects backend dependencies in `backend/.venv` and
-frontend dependencies in `frontend/node_modules`:
+The hybrid workflow expects backend dependencies in `backend/.venv` and frontend
+dependencies in `frontend/node_modules`:
 
 ```bash
 cd backend
@@ -565,20 +569,18 @@ cd ../frontend
 npm install
 ```
 
-By default, `make local-up` starts PostgreSQL and Redis via Homebrew services
-(`postgresql@16` and `redis`) and creates the expected `aifc` role/database if
-they are missing. If those services are managed separately, start them yourself
-and run:
-
-```bash
-make local-up LOCAL_INFRA=external
-```
+`make local-up` bind-mounts `./backend/storage` and `./backend/models` into the
+Docker worker so files written by the host FastAPI process are visible to the
+worker. The hybrid worker uses relative `STORAGE_PATH=storage` /
+`MODELS_PATH=models` inside the backend container so completed job paths remain
+portable back to the host API. Override the bind-mounted host paths if needed
+with `LOCAL_STORAGE_DIR` or `LOCAL_MODELS_DIR`.
 
 Useful overrides:
 
 ```bash
 make docker-up COMPOSE=docker-compose
-make local-up BREW_POSTGRES_SERVICE=postgresql@15
+make local-up LOCAL_STORAGE_DIR=./storage LOCAL_MODELS_DIR=./models
 make local-up LOCAL_BACKEND_PORT=8010 LOCAL_FRONTEND_PORT=3010
 ```
 

--- a/backend/app/api/v1/jobs.py
+++ b/backend/app/api/v1/jobs.py
@@ -1,8 +1,9 @@
 """Job API endpoints: POST /jobs, GET /jobs/{id}, GET /jobs."""
 
 import json
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, cast
 from uuid import UUID
 
 from fastapi import (
@@ -232,7 +233,10 @@ async def retry_job(
     job.output_file = None
     await db.flush()
 
-    process_job.delay(str(job.id), dict(job.config))
+    stored_config = cast(Mapping[str, Any], getattr(job, "config"))
+    retry_config: dict[str, Any] = dict(stored_config)
+    JobConfig.model_validate(retry_config)
+    process_job.delay(str(job.id), retry_config)
     return JobCreateResponse(job_id=str(job.id))
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -9,7 +9,7 @@ class Settings(BaseSettings):
     """Application settings loaded from environment variables / .env file."""
 
     model_config = SettingsConfigDict(
-        env_file=".env",
+        env_file=("../.env", ".env", "backend/.env"),
         env_file_encoding="utf-8",
         extra="ignore",
     )

--- a/backend/app/tasks/placeholder.py
+++ b/backend/app/tasks/placeholder.py
@@ -1,11 +1,14 @@
 """Celery task that runs the PDF-to-DXF conversion pipeline."""
 
+# cspell:words autoretry
+
 from __future__ import annotations
 
 import asyncio
 import traceback
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, ParamSpec, Protocol, TypeVar, cast
 from uuid import UUID
 
 from sqlalchemy import select
@@ -28,6 +31,44 @@ from app.pipeline import (
 )
 from app.pipeline.progress import get_progress_publisher
 from app.tasks.celery_app import celery_app
+
+_P = ParamSpec("_P")
+_R_co = TypeVar("_R_co", covariant=True)
+
+
+class _CeleryTask(Protocol[_P, _R_co]):
+    """Typed subset of a registered Celery task used by API enqueue sites."""
+
+    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _R_co:
+        """Run the task synchronously with the wrapped function signature."""
+        ...
+
+    def delay(self, *args: Any, **kwargs: Any) -> Any:
+        """Enqueue the task asynchronously via Celery."""
+        ...
+
+
+class _TypedCeleryApp(Protocol):
+    """Typed subset of Celery used to register tasks in this module."""
+
+    def task(
+        self, *args: Any, **kwargs: Any
+    ) -> Callable[[Callable[_P, _R_co]], _CeleryTask[_P, _R_co]]:
+        """Return a decorator that produces a typed Celery task object."""
+        ...
+
+
+def celery_task(
+    *args: Any, **kwargs: Any
+) -> Callable[[Callable[_P, _R_co]], _CeleryTask[_P, _R_co]]:
+    """Return a typed Celery task decorator for Pylance/Pyright.
+
+    Celery's dynamic ``task`` API is typed as partially unknown, which causes
+    static analysis to treat decorated functions as untyped. This wrapper keeps
+    the runtime behavior unchanged while exposing both the original callable
+    signature and Celery task methods such as ``delay`` to type checkers.
+    """
+    return cast(_TypedCeleryApp, celery_app).task(*args, **kwargs)
 
 
 def publish_progress(job_id: str, status: str, progress: int, step: str) -> None:
@@ -71,7 +112,7 @@ def portable_storage_path(path: Path | None) -> str | None:
     return str(storage_path / relative_path)
 
 
-@celery_app.task(
+@celery_task(
     bind=True,
     name="app.tasks.placeholder.process_job",
     autoretry_for=(Exception,),

--- a/backend/app/tasks/placeholder.py
+++ b/backend/app/tasks/placeholder.py
@@ -10,6 +10,7 @@ from uuid import UUID
 
 from sqlalchemy import select
 
+from app.core.config import get_settings
 from app.core.database import async_session
 from app.models.job import Job
 from app.pipeline import (
@@ -44,6 +45,30 @@ def publish_progress(job_id: str, status: str, progress: int, step: str) -> None
         progress=progress,
         step=step,
     )
+
+
+def portable_storage_path(path: Path | None) -> str | None:
+    """Return a storage path that is portable across host and container runtimes.
+
+    Hybrid local development runs the API on the host and the worker in Docker.
+    Persisting an absolute container path such as ``/app/storage/...`` would make
+    the host API unable to serve completed outputs. When an output lives under
+    ``settings.STORAGE_PATH``, persist it relative to that configured storage
+    root if the root itself is relative; otherwise keep the absolute path used by
+    the all-Docker workflow.
+    """
+    if path is None:
+        return None
+
+    storage_path = Path(get_settings().STORAGE_PATH)
+    storage_base = storage_path.resolve()
+    resolved_path = path.resolve()
+    try:
+        relative_path = resolved_path.relative_to(storage_base)
+    except ValueError:
+        return str(path)
+
+    return str(storage_path / relative_path)
 
 
 @celery_app.task(
@@ -130,7 +155,7 @@ async def _process_job_async(job_id: str, config: dict[str, Any]) -> str:
         job.status = "completed"
         job.progress = 100
         job.step = "Completed"
-        job.output_file = str(result_context.output_path) if result_context.output_path else None
+        job.output_file = portable_storage_path(result_context.output_path)
         page_count = result_context.metadata.get("page_count")
         if isinstance(page_count, int):
             job.page_count = page_count

--- a/backend/tests/test_placeholder_task_paths.py
+++ b/backend/tests/test_placeholder_task_paths.py
@@ -1,0 +1,63 @@
+"""Tests for worker-persisted storage paths."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from pytest import MonkeyPatch
+
+from app.tasks import placeholder
+
+
+def test_portable_storage_path_keeps_relative_storage_paths(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Hybrid local workers persist paths the host API can resolve too."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        placeholder,
+        "get_settings",
+        lambda: SimpleNamespace(STORAGE_PATH="storage"),
+    )
+
+    output_path = tmp_path / "storage" / "job-1" / "output" / "output.dxf"
+    output_path.parent.mkdir(parents=True)
+    output_path.touch()
+
+    assert placeholder.portable_storage_path(output_path) == "storage/job-1/output/output.dxf"
+
+
+def test_portable_storage_path_keeps_absolute_storage_paths(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """All-Docker/absolute storage configurations keep absolute paths."""
+    storage_path = tmp_path / "storage"
+    monkeypatch.setattr(
+        placeholder,
+        "get_settings",
+        lambda: SimpleNamespace(STORAGE_PATH=str(storage_path)),
+    )
+
+    output_path = storage_path / "job-1" / "output" / "output.dxf"
+    output_path.parent.mkdir(parents=True)
+    output_path.touch()
+
+    assert placeholder.portable_storage_path(output_path) == str(output_path)
+
+
+def test_portable_storage_path_keeps_paths_outside_storage(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Unexpected paths outside storage are not rewritten."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        placeholder,
+        "get_settings",
+        lambda: SimpleNamespace(STORAGE_PATH="storage"),
+    )
+
+    outside_path = tmp_path / "elsewhere" / "output.dxf"
+
+    assert placeholder.portable_storage_path(outside_path) == str(outside_path)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,16 +34,16 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://aifc:aifc@postgres:5432/aifc
       REDIS_URL: redis://redis:6379/0
-      STORAGE_PATH: /app/storage
+      STORAGE_PATH: ${STORAGE_PATH:-/app/storage}
       STORAGE_TTL_DAYS: 7
-      MODELS_PATH: /app/models
+      MODELS_PATH: ${MODELS_PATH:-/app/models}
       DWG_CONVERTER_COMMAND: ${DWG_CONVERTER_COMMAND:-}
       CORS_ORIGINS: '["http://localhost:3000"]'
       DEBUG: "true"
     volumes:
       - ./backend:/app
-      - storage_data:/app/storage
-      - models_data:/app/models
+      - ${STORAGE_VOLUME:-storage_data}:/app/storage
+      - ${MODELS_VOLUME:-models_data}:/app/models
     depends_on:
       postgres:
         condition: service_healthy
@@ -56,14 +56,14 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://aifc:aifc@postgres:5432/aifc
       REDIS_URL: redis://redis:6379/0
-      STORAGE_PATH: /app/storage
+      STORAGE_PATH: ${STORAGE_PATH:-/app/storage}
       STORAGE_TTL_DAYS: 7
-      MODELS_PATH: /app/models
+      MODELS_PATH: ${MODELS_PATH:-/app/models}
       DWG_CONVERTER_COMMAND: ${DWG_CONVERTER_COMMAND:-}
     volumes:
       - ./backend:/app
-      - storage_data:/app/storage
-      - models_data:/app/models
+      - ${STORAGE_VOLUME:-storage_data}:/app/storage
+      - ${MODELS_VOLUME:-models_data}:/app/models
     depends_on:
       postgres:
         condition: service_healthy
@@ -76,14 +76,14 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://aifc:aifc@postgres:5432/aifc
       REDIS_URL: redis://redis:6379/0
-      STORAGE_PATH: /app/storage
+      STORAGE_PATH: ${STORAGE_PATH:-/app/storage}
       STORAGE_TTL_DAYS: 7
-      MODELS_PATH: /app/models
+      MODELS_PATH: ${MODELS_PATH:-/app/models}
       DWG_CONVERTER_COMMAND: ${DWG_CONVERTER_COMMAND:-}
     volumes:
       - ./backend:/app
-      - storage_data:/app/storage
-      - models_data:/app/models
+      - ${STORAGE_VOLUME:-storage_data}:/app/storage
+      - ${MODELS_VOLUME:-models_data}:/app/models
     depends_on:
       postgres:
         condition: service_healthy
@@ -96,7 +96,7 @@ services:
     profiles:
       - dwg
     volumes:
-      - storage_data:/app/storage
+      - ${STORAGE_VOLUME:-storage_data}:/app/storage
     command: sh -c "echo 'Mount ODA FileConverter or libredwg here for DWG_CONVERTER_COMMAND' && tail -f /dev/null"
 
   frontend:


### PR DESCRIPTION
Implemented the requested root-level Make workflow and pushed it to GitHub.
- Added root `Makefile`.
- Added one-command Docker startup/shutdown:
  - `make docker-up`
  - `make docker-down`
- Added one-command non-Docker startup/shutdown:
  - `make local-up`
  - `make local-down`
  - aliases: `make up`, `make down`, `make restart`
- Added service-specific Docker commands for `postgres`, `redis`, `backend`, `worker`, `beat`, and `frontend`, plus generic `SERVICE=<name>` targets.
- Added service-specific non-Docker commands for local PostgreSQL/Redis and PID-managed backend, worker, beat, and frontend processes.
- Added `.make/` PID/log runtime management and ignored it in `.gitignore`.
- Added `make local-db-setup` to create the expected local `aifc` PostgreSQL role/database for Homebrew-based local development.
- Updated backend config loading so local backend commands run from `backend/` can still read the root `.env`.
- Updated `README.md` with the Makefile workflows and examples.
