### PR TITLE
Fix/job progress visibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ coverage/
 frontend/.env
 frontend/.env.local
 frontend/.env.*.local
+.env.local
+.env
 
 # ─── Python / Backend ─────────────────────────────────────────
 # Byte-compiled / optimized

--- a/.talismanrc
+++ b/.talismanrc
@@ -13,6 +13,8 @@ fileignoreconfig:
   checksum: e2d4b634d51975aea55e32f43c51b61c1d5621a9756959b6258ebb955b7e6f2b
 - filename: docs/TODO.md
   checksum: b5f17b6cf01637330d67c5ba181ae4325b52840fc321c21964bdb544638cf8bf
+- filename: backend/app/api/v1/jobs_stream.py
+  checksum: 6e6a351f846e5d70ba0879f6f78dc97b9ce7cff45062aa5e5c6492a7b062dfbc
 - filename: frontend/src/components/job/PageViewer.tsx
   checksum: 161987d127228af51e82420c88594a54b972c9c7ae6814a36263804cfebc8a31
 - filename: frontend/src/components/job/ImageModal.tsx

--- a/.talismanrc
+++ b/.talismanrc
@@ -11,8 +11,8 @@ fileignoreconfig:
   checksum: 029fbcf2e43a8b51d187cc9f29a8eeb3de4504a14d5b9c1120072cf950f00d33
 - filename: frontend/package-lock.json
   checksum: e2d4b634d51975aea55e32f43c51b61c1d5621a9756959b6258ebb955b7e6f2b
-- filename: TODO.md
-  checksum: 3261b46f8b7969a77ed40492f2e3aadec3a2ad42bb9bf21e8d7e5728c47247a6
+- filename: docs/TODO.md
+  checksum: b5f17b6cf01637330d67c5ba181ae4325b52840fc321c21964bdb544638cf8bf
 - filename: frontend/src/components/job/PageViewer.tsx
   checksum: 161987d127228af51e82420c88594a54b972c9c7ae6814a36263804cfebc8a31
 - filename: frontend/src/components/job/ImageModal.tsx

--- a/Makefile
+++ b/Makefile
@@ -49,23 +49,39 @@ endef
 define stop_host_service
 	@if [ -f "$(PID_DIR)/$(1).pid" ]; then \
 		PID="$$(cat "$(PID_DIR)/$(1).pid")"; \
+		list_tree() { \
+			echo "$$1"; \
+			for child in $$(pgrep -P "$$1" 2>/dev/null); do \
+				list_tree "$$child"; \
+			done; \
+		}; \
 		if kill -0 "$$PID" 2>/dev/null; then \
-			echo "Stopping host $(1) (pid $$PID)..."; \
-			kill "$$PID" 2>/dev/null || true; \
+			echo "Stopping host $(1) (pid $$PID) and its process tree..."; \
+			TREE_PIDS="$$(list_tree "$$PID" | sort -rn | uniq)"; \
+			kill -TERM $$TREE_PIDS 2>/dev/null || true; \
 			for _ in $$(seq 1 10); do \
-				kill -0 "$$PID" 2>/dev/null || break; \
+				ALIVE=0; \
+				for p in $$TREE_PIDS; do \
+					if kill -0 "$$p" 2>/dev/null; then ALIVE=1; break; fi; \
+				done; \
+				[ "$$ALIVE" -eq 0 ] && break; \
 				sleep 1; \
 			done; \
-			if kill -0 "$$PID" 2>/dev/null; then \
-				echo "Force stopping host $(1) (pid $$PID)..."; \
-				kill -9 "$$PID" 2>/dev/null || true; \
+			ALIVE=0; \
+			for p in $$TREE_PIDS; do \
+				if kill -0 "$$p" 2>/dev/null; then ALIVE=1; break; fi; \
+			done; \
+			if [ "$$ALIVE" -eq 1 ]; then \
+				echo "Force stopping host $(1) process tree (pids: $$TREE_PIDS)..."; \
+				kill -KILL $$TREE_PIDS 2>/dev/null || true; \
 			fi; \
+			echo "host $(1) stopped"; \
 		else \
-			echo "$(1) pid file exists, but process $$PID is not running"; \
+			echo "host $(1) pid file exists, but process $$PID is not running"; \
 		fi; \
 		rm -f "$(PID_DIR)/$(1).pid"; \
 	else \
-		echo "host $(1) is not running"; \
+		echo "host $(1) is not running (no pid file; if started outside make, stop it manually)"; \
 	fi
 endef
 

--- a/backend/app/api/v1/jobs_stream.py
+++ b/backend/app/api/v1/jobs_stream.py
@@ -43,7 +43,7 @@ async def stream_job_progress(job_id: str) -> EventSourceResponse:
                     yield {"event": "progress", "data": data}
                     try:
                         payload = json.loads(data)
-                        if payload.get("status") == "completed":
+                        if payload.get("status") in ("completed", "failed"):
                             break
                     except (json.JSONDecodeError, KeyError):
                         pass

--- a/backend/app/api/v1/jobs_stream.py
+++ b/backend/app/api/v1/jobs_stream.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import json
+from collections.abc import AsyncIterator
+from typing import Any, Protocol, cast
 
 import redis.asyncio as aioredis
 from fastapi import APIRouter
@@ -11,6 +13,46 @@ from app.core.config import get_settings
 
 router = APIRouter()
 settings = get_settings()
+
+
+class _ProgressPubSub(Protocol):
+    """Typed subset of the redis.asyncio Pub/Sub API used by this endpoint.
+
+    redis-py's asyncio surface is only partially annotated, so the stream
+    casts to this protocol to keep strict type checking precise.
+    """
+
+    async def subscribe(self, channel: str) -> object:
+        """Subscribe to a Redis Pub/Sub channel."""
+        ...
+
+    async def unsubscribe(self, channel: str) -> object:
+        """Unsubscribe from a Redis Pub/Sub channel."""
+        ...
+
+    async def get_message(
+        self, *, ignore_subscribe_messages: bool, timeout: float | None
+    ) -> dict[str, Any] | None:
+        """Return the next pending Pub/Sub message, if any."""
+        ...
+
+
+class _ProgressRedis(Protocol):
+    """Typed subset of the redis.asyncio client API used by this endpoint."""
+
+    def pubsub(self) -> _ProgressPubSub:
+        """Return a Pub/Sub handle."""
+        ...
+
+    async def close(self) -> None:
+        """Close the client and release its connection pool."""
+        ...
+
+
+def _open_redis() -> _ProgressRedis:
+    """Create the Redis client used for progress streaming."""
+    client = cast(Any, aioredis).from_url(settings.REDIS_URL)
+    return cast(_ProgressRedis, client)
 
 
 @router.get("/jobs/{job_id}/stream")
@@ -28,24 +70,28 @@ async def stream_job_progress(job_id: str) -> EventSourceResponse:
     """
     channel = f"job:{job_id}"
 
-    async def event_generator():
+    async def event_generator() -> AsyncIterator[dict[str, str]]:
         """Generate SSE events from Redis Pub/Sub."""
-        r = aioredis.from_url(settings.REDIS_URL)
+        r = _open_redis()
         pubsub = r.pubsub()
         await pubsub.subscribe(channel)
         try:
             while True:
                 message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0)
                 if message and message["type"] == "message":
-                    data = message["data"]
-                    if isinstance(data, bytes):
-                        data = data.decode("utf-8")
+                    raw = message["data"]
+                    if isinstance(raw, bytes):
+                        data = raw.decode("utf-8")
+                    elif isinstance(raw, str):
+                        data = raw
+                    else:
+                        data = str(raw)
                     yield {"event": "progress", "data": data}
                     try:
-                        payload = json.loads(data)
+                        payload: dict[str, Any] = json.loads(data)
                         if payload.get("status") in ("completed", "failed"):
                             break
-                    except (json.JSONDecodeError, KeyError):
+                    except (json.JSONDecodeError, KeyError, TypeError):
                         pass
                 await asyncio.sleep(0.1)
         finally:

--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -12,6 +12,7 @@ celery_app = Celery(
     "ai_file_converter",
     broker=settings.REDIS_URL,
     backend=settings.REDIS_URL,
+    include=["app.tasks.placeholder", "app.tasks.cleanup"],
 )
 
 celery_app.conf.update(
@@ -29,8 +30,6 @@ celery_app.conf.update(
         },
     },
 )
-
-celery_app.autodiscover_tasks(["app.tasks"])
 
 
 @worker_process_init.connect

--- a/backend/app/tasks/placeholder.py
+++ b/backend/app/tasks/placeholder.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import traceback
 from collections.abc import Callable
 from pathlib import Path
@@ -31,6 +32,8 @@ from app.pipeline import (
 )
 from app.pipeline.progress import get_progress_publisher
 from app.tasks.celery_app import celery_app
+
+LOGGER = logging.getLogger(__name__)
 
 _P = ParamSpec("_P")
 _R_co = TypeVar("_R_co", covariant=True)
@@ -147,6 +150,13 @@ async def _process_job_async(job_id: str, config: dict[str, Any]) -> str:
         job.error_msg = None
         job.error_trace = None
         await session.commit()
+        publish_progress(job_id, "processing", 0, "Starting")
+        LOGGER.info(
+            "Job %s: starting conversion (mode=%s, output_format=%s)",
+            job_id,
+            config.get("mode"),
+            config.get("output_format"),
+        )
 
         if not job.input_file:
             raise ValueError(f"Job {job_id} has no input file")
@@ -176,9 +186,11 @@ async def _process_job_async(job_id: str, config: dict[str, Any]) -> str:
 
         pipeline = Pipeline.from_steps(*steps, publish_step_progress=False)
 
+        LOGGER.info("Job %s: running pipeline with %d step(s)", job_id, len(steps))
         try:
             result_context = pipeline.run(context)
         except Exception as exc:
+            LOGGER.error("Job %s: pipeline failed: %s", job_id, exc)
             job.status = "failed"
             job.step = "Failed"
             job.error_msg = str(exc)
@@ -202,5 +214,6 @@ async def _process_job_async(job_id: str, config: dict[str, Any]) -> str:
             job.page_count = page_count
         await session.commit()
 
+    LOGGER.info("Job %s: pipeline completed successfully", job_id)
     publish_progress(job_id, "completed", 100, "Completed")
     return "completed"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,6 +60,8 @@ sequenceDiagram
   A->>S: verify and stream file
 ```
 
+The worker publishes an initial `processing` event as soon as it claims the job, per-step events during the pipeline, and a terminal `completed` or `failed` event. The SSE endpoint closes the stream on either terminal status. The frontend also polls `GET /jobs/{id}` every 3 seconds as a fallback because Redis Pub/Sub does not replay events to late subscribers.
+
 ## Data model
 
 The core table is `jobs`, managed by Alembic migrations under `backend/alembic/versions/`.
@@ -96,7 +98,8 @@ The exact persisted path can be relative in hybrid local development so the host
 
 ## Boundaries
 
-- The frontend does not run conversion logic; it only uploads, polls/fetches, subscribes to SSE, previews, and downloads.
+- The frontend does not run conversion logic; it only uploads, polls/fetches, subscribes to SSE (with a polling fallback), previews, and downloads.
+- Celery task modules are registered explicitly via the `include` setting in `backend/app/tasks/celery_app.py`; a task module that is not listed there will not be executable by the worker.
 - FastAPI does not perform heavy conversion in request handlers; it creates jobs and serves files/status.
 - Pipeline steps are pluggable and operate on `PipelineContext`.
 - DWG generation is intentionally externalized because DWG is proprietary.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -135,8 +135,19 @@ make clean-local-runtime
 | Symptom | Check |
 | --- | --- |
 | Frontend cannot reach API | Confirm `NEXT_PUBLIC_API_URL` and backend port 8000. |
-| Jobs stay pending | Check worker logs and Redis health. |
+| Jobs stay pending | Confirm the worker is running (`make local-status` or `docker-compose ps`) and check `make logs-worker` for `Received unregistered task` errors. Task modules must be listed in the Celery `include` setting in `backend/app/tasks/celery_app.py`. |
+| No progress updates in UI | Conversion progress is emitted by the worker, not the API. Check `make logs-worker` (or `docker-compose logs worker`). The job page also polls the API every 3 seconds as a fallback, so confirm the backend is reachable. |
 | Downloads 404/409 | Confirm job is completed and output artifact exists. |
 | Page previews missing | Confirm parser produced `pages/page_0001.png` and `page_count`. |
 | DWG output missing | Confirm `output_format` and `DWG_CONVERTER_COMMAND`. |
 | Hybrid path issues | Confirm shared `LOCAL_STORAGE_DIR` and `LOCAL_MODELS_DIR`. |
+
+## Logging
+
+| Log target | Contents |
+| --- | --- |
+| `make logs-backend` / `docker-compose logs backend` | FastAPI HTTP requests and API errors. |
+| `make logs-worker` / `docker-compose logs worker` | Celery task lifecycle and conversion progress lines from `app.tasks.placeholder` (starting, step count, success/failure). |
+| `make logs-frontend` | Next.js dev server output. |
+
+Conversion status is logged by the worker, not the API. Watching only backend logs will not show conversion progress.

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -51,6 +51,18 @@ flowchart TD
 | GLB writing | `glb_writer.py` | Export self-contained GLB for browser preview and download. | 97% |
 | DWG conversion | `dwg_converter.py` | Run configured external converter command. | 98% |
 
+## Progress reporting
+
+The task publishes progress through Redis Pub/Sub on channel `job:{job_id}`:
+
+1. `processing` / 0% / `Starting` as soon as the worker claims the job.
+2. One event per step (see Typical progress above) as each step completes.
+3. `completed` / 100% or `failed` with the error message as the terminal event.
+
+The FastAPI SSE endpoint forwards these events and closes the stream on `completed` or `failed`. The job page also polls the REST API every 3 seconds, so progress stays visible even if the browser subscribed after some events were published.
+
+The task also logs lifecycle lines (`Job {id}: starting conversion`, `running pipeline with N step(s)`, `pipeline completed successfully`, or `pipeline failed`) to the worker log.
+
 ## Output layers and artifacts
 
 DXF outputs use domain-oriented layers such as:

--- a/docs/risks-and-edge-cases.md
+++ b/docs/risks-and-edge-cases.md
@@ -29,6 +29,8 @@ DrawLift operates in a domain where input quality varies widely. This document l
 | PostgreSQL unavailable | API and worker cannot persist state. | Docker health checks; no HA in POC. |
 | Storage path mismatch | API cannot serve worker outputs. | `portable_storage_path` supports hybrid host/Docker paths. |
 | Cleanup deletes files | Historical jobs become archived and downloads unavailable. | TTL is explicit via `STORAGE_TTL_DAYS`. |
+| Late SSE subscriber | Browser opens the stream after events were published and misses them. | Frontend polls `GET /jobs/{id}` every 3 seconds as a fallback and applies terminal states authoritatively. |
+| Unregistered Celery task | Queued jobs are discarded and stay pending. | Task modules are explicitly listed in the Celery `include` setting; worker logs surface `Received unregistered task` errors. |
 
 ## API edge cases
 

--- a/frontend/src/components/job/ProgressTracker.tsx
+++ b/frontend/src/components/job/ProgressTracker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { getJob } from "@/lib/api";
 import { createSSEStream } from "@/lib/sse";
 import { SSEProgressEvent, JobStatus } from "@/types/api";
 
@@ -58,6 +59,53 @@ export default function ProgressTracker({
     );
 
     return () => eventSource.close();
+  }, [initialStatus, jobId, onComplete]);
+
+  // Poll the REST API as a fallback so the UI stays in sync when SSE
+  // events are missed (Redis Pub/Sub does not replay past events).
+  useEffect(() => {
+    if (
+      initialStatus === "completed" ||
+      initialStatus === "failed" ||
+      initialStatus === "archived"
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+    let interval: ReturnType<typeof setInterval> | undefined;
+
+    const poll = async () => {
+      try {
+        const job = await getJob(jobId);
+        if (cancelled) return;
+
+        if (job.status === "completed" || job.status === "failed" || job.status === "archived") {
+          setProgress(job.progress);
+          setStep(job.step ?? "");
+          setStatus(job.status);
+          setMessage(job.error_msg ?? null);
+          if (interval) clearInterval(interval);
+          onComplete?.();
+          return;
+        }
+
+        // Only advance state; SSE may already be ahead of the database.
+        setStatus((current) =>
+          current === "pending" || current === "queued" ? job.status : current
+        );
+        setProgress((current) => Math.max(current, job.progress));
+      } catch {
+        // Transient polling errors are ignored; SSE remains the primary channel.
+      }
+    };
+
+    interval = setInterval(poll, 3000);
+
+    return () => {
+      cancelled = true;
+      if (interval) clearInterval(interval);
+    };
   }, [initialStatus, jobId, onComplete]);
 
   return (

--- a/typings/celery/__init__.pyi
+++ b/typings/celery/__init__.pyi
@@ -1,0 +1,31 @@
+"""Minimal local type stubs for Celery.
+
+Celery does not ship a ``py.typed`` marker, so strict type checkers
+report missing stubs and partially unknown member types. These stubs
+cover only the Celery surface used by this project. Extend them here
+if new Celery APIs are introduced.
+"""
+
+from collections.abc import Callable
+from typing import Any, TypeVar, overload
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+class _Settings:
+    def update(self, **settings: Any) -> None: ...
+
+class Celery:
+    conf: _Settings
+    def __init__(
+        self,
+        main: str = ...,
+        *,
+        broker: str | None = ...,
+        backend: str | None = ...,
+        include: list[str] | None = ...,
+        **kwargs: Any,
+    ) -> None: ...
+    @overload
+    def task(self, fun: _F, **kwargs: Any) -> _F: ...
+    @overload
+    def task(self, **kwargs: Any) -> Callable[[_F], _F]: ...

--- a/typings/celery/signals.pyi
+++ b/typings/celery/signals.pyi
@@ -1,0 +1,14 @@
+"""Minimal local type stubs for ``celery.signals``.
+
+Covers only the signals used by this project. Extend as needed.
+"""
+
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+class BaseSignal:
+    def connect(self, fun: _F, **kwargs: Any) -> _F: ...
+
+worker_process_init: BaseSignal


### PR DESCRIPTION
## Fix job progress visibility

| # | Hash | Change |
|---|------|--------|
| 1 | `8534b5c` | **fix(worker): register Celery task modules via include list** — replaced broken `autodiscover_tasks(["app.tasks"])` (which looked for nonexistent `app.tasks.tasks`) with `include=["app.tasks.placeholder", "app.tasks.cleanup"]` in `celery_app.py`. This was the blocker: the worker discarded every queued job as "Received unregistered task". |
| 2 | `027ce65` | **feat(worker): emit initial processing event and conversion logs** — `placeholder.py` now publishes a `processing`/0%/`Starting` Redis event immediately after claiming the job, and logs lifecycle lines (`starting conversion`, `running pipeline with N step(s)`, `pipeline completed successfully`, `pipeline failed`) so `make logs-worker` shows conversion status. |
| 3 | `a4e94ab` | **fix(api): close SSE stream on failed job status** — `jobs_stream.py` now treats both `completed` and `failed` as terminal, so failed-job streams close cleanly instead of hanging open. |
| 4 | `10a5f9c` | **feat(frontend): add polling fallback to progress tracker** — `ProgressTracker.tsx` polls `GET /jobs/{id}` every 3s while active. Terminal DB states are applied authoritatively; active polls only advance status/progress, so SSE state ahead of the DB is never regressed. Fixes missed Redis Pub/Sub events for late subscribers. |
| 5 | `c0eb6a1` | **docs: document progress events, worker logs, and fallbacks** — updated `operations.md` (troubleshooting rows + new Logging section clarifying conversion logs live in worker logs), `architecture.md` (event sequence, polling fallback, include registration), `pipeline.md` (new Progress reporting section), `risks-and-edge-cases.md` (late SSE subscriber + unregistered task risks). |
| 6 | `7ef3697` | **chore: update talisman ignore path for moved TODO.md** — the pre-push scan blocked on a false positive because `TODO.md` moved to `docs/TODO.md`; updated the stale `.talismanrc` entry with the new path and Talisman-suggested checksum. |

## Type issues fixed in `celery_app.py` and `jobs_stream.py`

All 13 strict type-checker errors are resolved, verified, committed, and pushed to `fix/job-progress-visibility` (no PR).

### Root causes and fixes

**`backend/app/tasks/celery_app.py`** (4 errors) — Celery ships no `py.typed` marker, so strict checkers reported "Stub file not found" and partially unknown types for `Celery()`, `conf.update`, and `worker_process_init.connect`.
- **Fix**: added minimal local stubs `typings/celery/__init__.pyi` and `typings/celery/signals.pyi` (auto-detected by Pylance/pyright at the workspace root), covering exactly the Celery surface this project uses. `celery_app.py` itself needed no changes.

**`backend/app/api/v1/jobs_stream.py`** (8 errors) — redis-py's asyncio API is only partially annotated (`from_url`, `pubsub`, `subscribe`/`unsubscribe`, `get_message`), which strict checkers flag as partially unknown. There was also a latent real issue: `message["data"]` could be `None` per the types and was passed straight to `json.loads`.
- **Fix**: introduced fully-typed local protocols (`_ProgressRedis`, `_ProgressPubSub`) describing the exact redis surface used, cast the client to them, annotated the SSE generator as `AsyncIterator[dict[str, str]]`, and normalized message data to `str` (bytes → decode, str → pass, otherwise `str(...)`) so `json.loads` never receives `None`.


| Hash | Change |
|---|---|
| `e5d6edb` | fix(backend): satisfy strict type checking in celery app and SSE stream |
| `7fabc49` | chore: add talisman ignore for jobs_stream.py false positive (pre-push secret-scan false positive on the rewritten file) |

## The `Makefile` stop logic has been successfully fixed, tested, and pushed.

### Root Cause
When `make local-up` runs `local-up-backend` and `local-up-frontend`, it executes the commands wrapped in a background bash shell (e.g., `/bin/bash -lc "cd backend && uvicorn ..."`). The PID written to `.make/pids/*.pid` belongs to that bash wrapper shell, not the actual `uvicorn` or `node` child processes. When `make local-down` ran previously, it executed a simple `kill "$PID"`, which killed the wrapper script but left the underlying `uvicorn` and Next.js `node` process trees orphaned and still bound to ports 8000 and 3000.

### The Fix
I updated the `stop_host_service` macro in the `Makefile` to:
1. Identify the wrapper PID from the `.pid` file.
2. Recursively find the entire process tree branching off that PID using a custom shell function that wraps `pgrep -P`.
3. Issue a `kill -TERM` command to the wrapper *and* all its descendants.
4. Wait and verify they exit gracefully, falling back to a `kill -KILL` on any stubborn descendants if they remain alive after 10 seconds.

The fix is committed (`d75092b`) and pushed to the existing `fix/job-progress-visibility` branch. 
