### PR TITLE
feat(devops): implement US-032 GNU LibreDWG DWG sidecar

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -12,7 +12,7 @@ fileignoreconfig:
 - filename: frontend/package-lock.json
   checksum: 9abe9b9e245be5f3bde7e5df87c0ee67ec7152bbd879393c48c70dc0f43cddd1
 - filename: docs/TODO.md
-  checksum: d3722d1f2d6ee0eb1592ed2b8a182168a7f8e833d6a2e34cc6c3e2a4726edcac
+  checksum: c146fa4c1bd6258da9ee45111908a177a1b39553b9e70e07d86927fe17221c0e
 - filename: backend/app/api/v1/jobs_stream.py
   checksum: 6e6a351f846e5d70ba0879f6f78dc97b9ce7cff45062aa5e5c6492a7b062dfbc
 - filename: frontend/src/components/job/PageViewer.tsx
@@ -24,7 +24,7 @@ fileignoreconfig:
 - filename: backend/app/pipeline/steps/vectorizer.py
   checksum: 0fcbe749dae4efce40a06eb31615e82e71b79ad8c8fd56876d13388ac4283069
 - filename: backend/tests/test_dwg_converter_step.py
-  checksum: 084c308be1a36ecea40ee09d99aad0d306710bc7ac25134557dfd10437e2834c
+  checksum: 9e35d96ee0bdc9c4c7a5431961585d67f31cf5ca9d459ce2d6e4bb7ab90568d5
 - filename: backend/tests/test_jobs_management.py
   checksum: 586e55133d93dc713533e2ceac79ec90db7f5a20e41c84edddba0b4e85335937
 - filename: frontend/src/app/history/page.tsx
@@ -34,7 +34,7 @@ fileignoreconfig:
 - filename: backend/tests/test_placeholder_task_paths.py
   checksum: 9d4d13e1fb42553059aa323251d2b7e31f89c2c653a8fabaf3de5f6e6a9dfe94
 - filename: README.md
-  checksum: b5e84c2b670a321f7c98ad5bd59ee1161ea7a4c76bf18247e0aea8bc3c0d1583
+  checksum: 025d08ffdf0f2d390d71f80b2e443fb58bc703739af104d221f5a41c7a03ee65
 - filename: backend/tests/test_stale_job_recovery.py
   checksum: f3509c5c0e6b1b93691a00c5643a07deb30cc91565266c408a487f52491e4774
 - filename: backend/tests/test_celery_worker_config.py

--- a/Makefile
+++ b/Makefile
@@ -149,8 +149,9 @@ docker-logs: check-compose ## Follow logs for all Docker services
 docker-migrate: check-compose ## Run Alembic migrations in the Docker backend service
 	$(COMPOSE) exec backend alembic upgrade head
 
-docker-up-dwg: check-compose ## Start default Docker services plus the optional DWG converter profile
-	$(COMPOSE) --profile dwg up -d --build $(DOCKER_SERVICES) dwg-converter
+docker-up-dwg: check-compose ## Start GNU LibreDWG first, then the default stack with the DWG profile
+	$(COMPOSE) --profile dwg up -d --build dwg-converter
+	$(COMPOSE) --profile dwg up -d --build $(DOCKER_SERVICES)
 
 .PHONY: download-model validate-model
 download-model: check-backend-venv ## Download/provision the ONNX segmentation model (optional MODEL_URL=<url>)

--- a/README.md
+++ b/README.md
@@ -112,17 +112,23 @@ make local-down
 
 ### Optional DWG conversion
 
-DWG is proprietary, so DrawLift does not bundle converter binaries. Configure an external converter command when needed:
+DWG is proprietary, so DrawLift keeps conversion in an optional sidecar. The
+`dwg-converter` Compose profile now builds GNU LibreDWG from source and exports
+its CLIs to the runtime services through a shared `/opt/libredwg` volume. By
+default, Compose auto-configures:
 
 ```bash
-DWG_CONVERTER_COMMAND='dwgwrite {input} {output}' make docker-up
+DWG_CONVERTER_COMMAND='dwgwrite {input} {output}'
 ```
 
-Supported placeholders are `{input}`, `{output}`, `{input_dir}`, `{output_dir}`, and `{stem}`. The optional Compose profile can be started with:
+Supported placeholders are `{input}`, `{output}`, `{input_dir}`, `{output_dir}`, and `{stem}`. Start the sidecar profile with:
 
 ```bash
 make docker-up-dwg
 ```
+
+`DwgConverterStep` prefers GNU LibreDWG's `dxf2dwg`, then `dwgwrite`, and falls
+back to ODA FileConverter when operators override `DWG_CONVERTER_COMMAND`.
 
 ## API
 

--- a/backend/Dockerfile.libredwg
+++ b/backend/Dockerfile.libredwg
@@ -1,0 +1,67 @@
+FROM debian:bookworm-slim
+
+ARG LIBREDWG_VERSION=0.13.3
+ARG LIBREDWG_DIST=/opt/libredwg-dist
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV CFLAGS="-O0 -g0"
+
+WORKDIR /tmp/libredwg-src
+
+# Basic GNU LibreDWG build requirements from the official README:
+#   C compiler + make + autoconf/automake/libtool, plus curl/xz-utils to fetch
+#   and unpack the release tarball. Bindings are disabled to keep the build
+#   smaller and faster; DXF support stays enabled because dxf2dwg/dwgwrite need
+#   it for DXF -> DWG conversion.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        build-essential \
+        ca-certificates \
+        curl \
+        libtool \
+        pkg-config \
+        xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -L --fail --silent \
+        "https://ftp.gnu.org/gnu/libredwg/libredwg-${LIBREDWG_VERSION}.tar.xz" \
+        -o libredwg.tar.xz \
+    && tar -xf libredwg.tar.xz \
+    && cd "libredwg-${LIBREDWG_VERSION}" \
+    && ./configure --prefix="${LIBREDWG_DIST}" --disable-bindings --disable-python \
+    && make -j1 \
+    && make install \
+    && "${LIBREDWG_DIST}/bin/dwgwrite" --version \
+    && "${LIBREDWG_DIST}/bin/dxf2dwg" --version
+
+# The official dwgwrite CLI is `dwgwrite [-o DWGFILE] INFILE`, while the
+# application already standardised on `dwgwrite {input} {output}`. Replace the
+# installed binary inside the shared distribution tree with a compatibility
+# wrapper that keeps the two-positional-args contract working.
+RUN mv "${LIBREDWG_DIST}/bin/dwgwrite" "${LIBREDWG_DIST}/bin/dwgwrite-real" \
+    && cat > "${LIBREDWG_DIST}/bin/dwgwrite" <<'EOF' \
+    && chmod +x "${LIBREDWG_DIST}/bin/dwgwrite"
+#!/bin/sh
+set -eu
+
+if [ "$#" -ge 2 ] \
+   && [ "${1#-}" = "$1" ] \
+   && [ "${2#-}" = "$2" ]; then
+  input="$1"
+  output="$2"
+  shift 2
+  exec /opt/libredwg/bin/dwgwrite-real "$@" -o "$output" "$input"
+fi
+
+exec /opt/libredwg/bin/dwgwrite-real "$@"
+EOF
+
+COPY libredwg-entrypoint.sh /usr/local/bin/libredwg-entrypoint.sh
+RUN chmod +x /usr/local/bin/libredwg-entrypoint.sh \
+    && mkdir -p /app/storage /opt/libredwg
+
+WORKDIR /app
+ENTRYPOINT ["/usr/local/bin/libredwg-entrypoint.sh"]
+CMD ["sh", "-c", "echo 'GNU LibreDWG sidecar ready'; /opt/libredwg/bin/dwgwrite --version | head -1; tail -f /dev/null"]

--- a/backend/app/pipeline/steps/dwg_converter.py
+++ b/backend/app/pipeline/steps/dwg_converter.py
@@ -111,7 +111,8 @@ def _format_command(command: str, *, dxf_path: Path, dwg_path: Path) -> list[str
 def _default_converter_commands(*, dxf_path: Path, dwg_path: Path) -> list[list[str]]:
     """Return supported converter command candidates in preference order."""
     return [
-        ["dwgwrite", str(dxf_path), str(dwg_path)],
+        ["dxf2dwg", "-y", "-o", str(dwg_path), str(dxf_path)],
+        ["dwgwrite", "-y", "-o", str(dwg_path), str(dxf_path)],
         [
             "ODAFileConverter",
             str(dxf_path.parent),

--- a/backend/libredwg-entrypoint.sh
+++ b/backend/libredwg-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+
+mkdir -p /opt/libredwg
+cp -a /opt/libredwg-dist/. /opt/libredwg/
+
+exec "$@"

--- a/backend/tests/test_dwg_converter_step.py
+++ b/backend/tests/test_dwg_converter_step.py
@@ -8,7 +8,11 @@ from pathlib import Path
 import pytest
 
 from app.pipeline.context import PipelineContext
-from app.pipeline.steps.dwg_converter import DwgConverterStep, _format_command
+from app.pipeline.steps.dwg_converter import (
+    DwgConverterStep,
+    _default_converter_commands,
+    _format_command,
+)
 
 
 def test_dwg_converter_runs_configured_command_and_records_metadata(
@@ -80,3 +84,41 @@ def test_format_command_expands_documented_placeholders(tmp_path: Path) -> None:
         "--stem",
         "output",
     ]
+
+
+def test_default_converter_commands_prefer_libredwg_dxftodwg(tmp_path: Path) -> None:
+    """LibreDWG's official DXF -> DWG tools are preferred before ODA fallback."""
+    dxf_path = tmp_path / "output.dxf"
+    dwg_path = tmp_path / "output.dwg"
+
+    commands = _default_converter_commands(dxf_path=dxf_path, dwg_path=dwg_path)
+
+    assert commands[0] == ["dxf2dwg", "-y", "-o", str(dwg_path), str(dxf_path)]
+    assert commands[1] == ["dwgwrite", "-y", "-o", str(dwg_path), str(dxf_path)]
+
+
+def test_dwg_converter_auto_detects_libredwg_candidate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no command is configured, the step tries LibreDWG CLI tools first."""
+    dxf_path = tmp_path / "output.dxf"
+    dxf_path.write_text("0\nSECTION\n2\nEOF\n", encoding="utf-8")
+    dwg_path = tmp_path / "output.dwg"
+    seen: list[list[str]] = []
+
+    def fake_run(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        seen.append(command)
+        if command[0] == "dxf2dwg":
+            dwg_path.write_bytes(b"AC1015\x00DWG")
+            return subprocess.CompletedProcess(command, 0, "", "")
+        raise AssertionError(f"unexpected fallback command: {command}")
+
+    monkeypatch.setattr("app.pipeline.steps.dwg_converter.subprocess.run", fake_run)
+    context = PipelineContext(job_id="job-123", input_path=tmp_path / "input.pdf")
+    context.output_path = dxf_path
+
+    result = DwgConverterStep(output_path=dwg_path).execute(context)
+
+    assert result.metadata["dwg_converter"] == "auto-detect"
+    assert seen == [["dxf2dwg", "-y", "-o", str(dwg_path), str(dxf_path.resolve())]]

--- a/backend/tests/test_dwg_end_to_end.py
+++ b/backend/tests/test_dwg_end_to_end.py
@@ -1,0 +1,157 @@
+"""End-to-end DWG conversion tests for the GNU LibreDWG sidecar (US-032)."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from app.pipeline import DwgConverterStep, DxfWriterStep, PipelineContext
+from app.pipeline.primitives import (
+    OpeningPrimitive,
+    Point,
+    RoomPrimitive,
+    TextPrimitive,
+    WallPrimitive,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BACKEND_DIR = REPO_ROOT / "backend"
+LIBREDWG_IMAGE_TAG = "drawlift-libredwg:test"
+
+
+def dxf_primitives() -> list[object]:
+    """Return primitives spanning all semantic DXF layers."""
+    return [
+        WallPrimitive(start=Point(0, 0), end=Point(100, 0), thickness=5),
+        OpeningPrimitive(kind="door", insertion=Point(20, 0), width=12, height=4),
+        OpeningPrimitive(kind="window", insertion=Point(70, 0), width=20, height=3),
+        RoomPrimitive(polygon=(Point(0, 10), Point(100, 10), Point(100, 80), Point(0, 80))),
+        TextPrimitive(insertion=Point(10, 20), width=20, height=5, value="Room"),
+    ]
+
+
+def _write_stub_converter(path: Path) -> Path:
+    """Write a tiny converter that copies the DXF into a DWG-like file."""
+    path.write_text(
+        "#!/bin/sh\n"
+        "set -eu\n"
+        'infile="$1"\n'
+        'outfile="$2"\n'
+        "printf 'AC1027\\0DWG' > \"$outfile\"\n"
+        'cat "$infile" >> "$outfile"\n',
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+    return path
+
+
+def _build_pipeline_context(tmp_path: Path) -> tuple[PipelineContext, Path, Path]:
+    """Create a DXF via the real writer step and return DWG conversion inputs."""
+    dxf_path = tmp_path / "output.dxf"
+    dwg_path = tmp_path / "output.dwg"
+    context = PipelineContext(
+        job_id="job-dwg-e2e",
+        input_path=tmp_path / "input.pdf",
+        primitives=dxf_primitives(),
+    )
+    DxfWriterStep(output_path=dxf_path).execute(context)
+    return context, dxf_path, dwg_path
+
+
+def test_pipeline_dxf_to_dwg_end_to_end_with_converter_command(tmp_path: Path) -> None:
+    """T-107: the full DXF->DWG step succeeds with a real external command.
+
+    This test covers the application-level end-to-end behavior in CI without
+    depending on Docker by using a tiny local converter script as the external
+    CAD tool.
+    """
+    context, dxf_path, dwg_path = _build_pipeline_context(tmp_path)
+    converter = _write_stub_converter(tmp_path / "fake-dwgwrite.sh")
+
+    result = DwgConverterStep(
+        output_path=dwg_path,
+        command=f"{converter} {{input}} {{output}}",
+    ).execute(context)
+
+    assert result.metadata["dwg_path"] == dwg_path
+    assert result.metadata["dwg_converter"] == f"{converter} {{input}} {{output}}"
+    assert dwg_path.is_file()
+    assert dwg_path.read_bytes().startswith(b"AC1027\x00DWG")
+    assert dxf_path.is_file(), "DXF is preserved alongside DWG for download helpers"
+
+
+def _ensure_docker_available() -> None:
+    if shutil.which("docker") is None:
+        pytest.skip("docker CLI is not installed")
+    try:
+        subprocess.run(
+            ["docker", "info"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"docker is unavailable: {exc}")
+
+
+def test_libredwg_image_builds_and_converts_dxf_to_dwg(tmp_path: Path) -> None:
+    """T-107: real GNU LibreDWG sidecar converts a generated DXF into DWG.
+
+    The test is opt-in because it performs a source build inside Docker.
+    Set RUN_DOCKER_TESTS=1 to execute it. The DXF is staged in a repo-local
+    `.tmp-docker-tests/` mount path so the container can reliably access it.
+    """
+    if os.getenv("RUN_DOCKER_TESTS") != "1":
+        pytest.skip("set RUN_DOCKER_TESTS=1 to run Docker/libredwg integration tests")
+
+    _ensure_docker_available()
+
+    build = subprocess.run(
+        [
+            "docker",
+            "build",
+            "-f",
+            str(BACKEND_DIR / "Dockerfile.libredwg"),
+            "-t",
+            LIBREDWG_IMAGE_TAG,
+            str(BACKEND_DIR),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=1800,
+    )
+    assert build.returncode == 0, build.stderr or build.stdout
+
+    context, dxf_path, dwg_path = _build_pipeline_context(tmp_path)
+    shared_root = REPO_ROOT / ".tmp-docker-tests"
+    shared_root.mkdir(exist_ok=True)
+    docker_mount = Path(tempfile.mkdtemp(prefix="us032-dwg-", dir=shared_root))
+    mounted_dxf = docker_mount / dxf_path.name
+    mounted_dwg = docker_mount / dwg_path.name
+    shutil.copy2(dxf_path, mounted_dxf)
+
+    command = (
+        "docker run --rm "
+        f"-v {docker_mount}:/work "
+        f"{LIBREDWG_IMAGE_TAG} "
+        f"/opt/libredwg/bin/dxf2dwg -y -o /work/{mounted_dwg.name} /work/{mounted_dxf.name}"
+    )
+    try:
+        result = DwgConverterStep(output_path=mounted_dwg, command=command).execute(context)
+
+        assert result.metadata["dwg_path"] == mounted_dwg
+        assert mounted_dwg.is_file()
+        shutil.copy2(mounted_dwg, dwg_path)
+        assert dwg_path.is_file()
+        assert dwg_path.stat().st_size > 0
+        header = dwg_path.read_bytes()[:6]
+        assert header.startswith(b"AC10")
+    finally:
+        shutil.rmtree(docker_mount, ignore_errors=True)

--- a/backend/tests/test_dwg_sidecar_compose.py
+++ b/backend/tests/test_dwg_sidecar_compose.py
@@ -1,0 +1,87 @@
+"""Tests for the GNU LibreDWG sidecar Docker wiring (US-032)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_PATH = REPO_ROOT / "docker-compose.yml"
+DOCKERFILE_PATH = REPO_ROOT / "backend" / "Dockerfile.libredwg"
+ENTRYPOINT_PATH = REPO_ROOT / "backend" / "libredwg-entrypoint.sh"
+
+
+def _compose() -> dict[str, object]:
+    data = yaml.safe_load(COMPOSE_PATH.read_text())
+    assert isinstance(data, dict)
+    return data
+
+
+def _service(name: str) -> dict[str, object]:
+    services = _compose()["services"]
+    assert isinstance(services, dict)
+    service = services[name]
+    assert isinstance(service, dict)
+    return service
+
+
+def test_libredwg_dockerfile_exists() -> None:
+    """T-104: the repository contains a dedicated LibreDWG Dockerfile."""
+    assert DOCKERFILE_PATH.is_file()
+    assert ENTRYPOINT_PATH.is_file()
+
+
+def test_libredwg_dockerfile_builds_from_gnu_source() -> None:
+    """T-104: the Dockerfile downloads GNU LibreDWG and installs dwgwrite."""
+    content = DOCKERFILE_PATH.read_text()
+
+    assert "ftp.gnu.org/gnu/libredwg" in content
+    configure_line = (
+        './configure --prefix="${LIBREDWG_DIST}" ' "--disable-bindings --disable-python"
+    )
+    assert configure_line in content
+    assert "make install" in content
+    assert "dwgwrite-real" in content
+    assert 'ENTRYPOINT ["/usr/local/bin/libredwg-entrypoint.sh"]' in content
+
+
+def test_dwg_converter_profile_uses_libredwg_image() -> None:
+    """AC: the placeholder alpine profile is replaced by the GNU LibreDWG build."""
+    service = _service("dwg-converter")
+
+    build = service.get("build")
+    assert isinstance(build, dict)
+    assert build.get("context") == "./backend"
+    assert build.get("dockerfile") == "Dockerfile.libredwg"
+    assert service.get("profiles") == ["dwg"]
+
+
+def test_backend_worker_and_beat_auto_configure_dwgwrite_command() -> None:
+    """T-106: compose auto-configures DWG_CONVERTER_COMMAND for runtime services."""
+    expected = "${DWG_CONVERTER_COMMAND:-dwgwrite {input} {output}}"
+    expected_path = "/opt/libredwg/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    for service_name in ("backend", "worker", "beat"):
+        environment = _service(service_name)["environment"]
+        assert isinstance(environment, dict)
+        assert environment.get("DWG_CONVERTER_COMMAND") == expected
+        assert environment.get("PATH") == expected_path
+        assert environment.get("LD_LIBRARY_PATH") == "/opt/libredwg/lib"
+
+
+def test_runtime_services_mount_the_shared_libredwg_volume() -> None:
+    """The sidecar populates a shared /opt/libredwg tree for other services."""
+    for service_name in ("backend", "worker", "beat"):
+        volumes = _service(service_name)["volumes"]
+        assert isinstance(volumes, list)
+        assert "libredwg_root:/opt/libredwg:ro" in volumes
+
+    sidecar_volumes = _service("dwg-converter")["volumes"]
+    assert isinstance(sidecar_volumes, list)
+    assert "libredwg_root:/opt/libredwg" in sidecar_volumes
+
+
+def test_compose_declares_named_libredwg_volume() -> None:
+    volumes = _compose()["volumes"]
+    assert isinstance(volumes, dict)
+    assert "libredwg_root" in volumes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,13 +39,16 @@ services:
       MODELS_PATH: ${MODELS_PATH:-/app/models}
       SEGMENTER_MODEL_PATH: ${SEGMENTER_MODEL_PATH:-/app/models/semantic_segmenter.onnx}
       SEGMENTER_MODEL_URL: ${SEGMENTER_MODEL_URL:-https://raw.githubusercontent.com/Josh-Uvi/DrawLift/main/backend/models/semantic_segmenter.onnx}
-      DWG_CONVERTER_COMMAND: ${DWG_CONVERTER_COMMAND:-}
+      PATH: /opt/libredwg/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      LD_LIBRARY_PATH: /opt/libredwg/lib
+      DWG_CONVERTER_COMMAND: ${DWG_CONVERTER_COMMAND:-dwgwrite {input} {output}}
       CORS_ORIGINS: '["http://localhost:3000"]'
       DEBUG: "true"
     volumes:
       - ./backend:/app
       - ${STORAGE_VOLUME:-storage_data}:/app/storage
       - ${MODELS_VOLUME:-models_data}:/app/models
+      - libredwg_root:/opt/libredwg:ro
     depends_on:
       postgres:
         condition: service_healthy
@@ -63,12 +66,15 @@ services:
       MODELS_PATH: ${MODELS_PATH:-/app/models}
       SEGMENTER_MODEL_PATH: ${SEGMENTER_MODEL_PATH:-/app/models/semantic_segmenter.onnx}
       SEGMENTER_MODEL_URL: ${SEGMENTER_MODEL_URL:-https://raw.githubusercontent.com/Josh-Uvi/DrawLift/main/backend/models/semantic_segmenter.onnx}
-      DWG_CONVERTER_COMMAND: ${DWG_CONVERTER_COMMAND:-}
+      PATH: /opt/libredwg/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      LD_LIBRARY_PATH: /opt/libredwg/lib
+      DWG_CONVERTER_COMMAND: ${DWG_CONVERTER_COMMAND:-dwgwrite {input} {output}}
       JOB_STALE_TIMEOUT_SECONDS: ${JOB_STALE_TIMEOUT_SECONDS:-300}
     volumes:
       - ./backend:/app
       - ${STORAGE_VOLUME:-storage_data}:/app/storage
       - ${MODELS_VOLUME:-models_data}:/app/models
+      - libredwg_root:/opt/libredwg:ro
     depends_on:
       postgres:
         condition: service_healthy
@@ -88,12 +94,15 @@ services:
       MODELS_PATH: ${MODELS_PATH:-/app/models}
       SEGMENTER_MODEL_PATH: ${SEGMENTER_MODEL_PATH:-/app/models/semantic_segmenter.onnx}
       SEGMENTER_MODEL_URL: ${SEGMENTER_MODEL_URL:-https://raw.githubusercontent.com/Josh-Uvi/DrawLift/main/backend/models/semantic_segmenter.onnx}
-      DWG_CONVERTER_COMMAND: ${DWG_CONVERTER_COMMAND:-}
+      PATH: /opt/libredwg/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      LD_LIBRARY_PATH: /opt/libredwg/lib
+      DWG_CONVERTER_COMMAND: ${DWG_CONVERTER_COMMAND:-dwgwrite {input} {output}}
       JOB_STALE_TIMEOUT_SECONDS: ${JOB_STALE_TIMEOUT_SECONDS:-300}
     volumes:
       - ./backend:/app
       - ${STORAGE_VOLUME:-storage_data}:/app/storage
       - ${MODELS_VOLUME:-models_data}:/app/models
+      - libredwg_root:/opt/libredwg:ro
     depends_on:
       postgres:
         condition: service_healthy
@@ -102,12 +111,14 @@ services:
     command: celery -A app.tasks.celery_app beat --loglevel=info
 
   dwg-converter:
-    image: alpine:3.20
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.libredwg
     profiles:
       - dwg
     volumes:
       - ${STORAGE_VOLUME:-storage_data}:/app/storage
-    command: sh -c "echo 'Mount ODA FileConverter or libredwg here for DWG_CONVERTER_COMMAND' && tail -f /dev/null"
+      - libredwg_root:/opt/libredwg
 
   frontend:
     build: ./frontend
@@ -123,3 +134,4 @@ volumes:
   redis_data:
   storage_data:
   models_data:
+  libredwg_root:

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -583,17 +583,19 @@
 
 ### US-032 · As a devops engineer, I want a libredwg Docker sidecar for DXF→DWG conversion
 
-- **Priority:** P1 · **Effort:** M · **Status:** 🟦 Todo · **Labels:** `area:devops`, `type:feature`
+- **Priority:** P1 · **Effort:** M · **Status:** 👀 In Review · **Labels:** `area:devops`, `type:feature`
 - **Acceptance Criteria:**
-  - [ ] `libredwg` Docker image builds successfully from source
-  - [ ] `dwg-converter` Compose profile uses the libredwg image instead of alpine placeholder
-  - [ ] `DWG_CONVERTER_COMMAND` is auto-configured to `dwgwrite {input} {output}` in compose
-  - [ ] End-to-end test: DXF→DWG conversion via sidecar produces a valid DWG file
+  - [x] `libredwg` Docker image builds successfully from source
+  - [x] `dwg-converter` Compose profile uses the libredwg image instead of alpine placeholder
+  - [x] `DWG_CONVERTER_COMMAND` is auto-configured to `dwgwrite {input} {output}` in compose
+  - [x] End-to-end test: DXF→DWG conversion via sidecar produces a valid DWG file
 - **Tasks:**
-  - [ ] T-104 — Create `backend/Dockerfile.libredwg` building `dwgwrite` from GNU LibreDWG source
-  - [ ] T-105 — Update `dwg-converter` Compose profile to use libredwg image with storage volume mount
-  - [ ] T-106 — Set `DWG_CONVERTER_COMMAND='dwgwrite {input} {output}'` in docker-compose.yml
-  - [ ] T-107 — Add end-to-end test: generate DXF via pipeline, convert to DWG via sidecar, validate output
+  - [x] T-104 — Create `backend/Dockerfile.libredwg` building `dwgwrite` from GNU LibreDWG source
+  - [x] T-105 — Update `dwg-converter` Compose profile to use libredwg image with storage volume mount
+  - [x] T-106 — Set `DWG_CONVERTER_COMMAND='dwgwrite {input} {output}'` in docker-compose.yml
+  - [x] T-107 — Add end-to-end test: generate DXF via pipeline, convert to DWG via sidecar, validate output
+- **Implementation notes:**
+  - The GNU LibreDWG image is built from the official 0.13.3 source tarball and installed into a shared `/opt/libredwg` volume that the `backend`, `worker`, and `beat` services mount read-only. Compose auto-configures `DWG_CONVERTER_COMMAND='dwgwrite {input} {output}'`; the image provides a compatibility wrapper translating that two-positional-args contract to LibreDWG's native `dwgwrite -o OUTFILE INFILE` CLI. The runtime step now prefers `dxf2dwg` first, then `dwgwrite`, before falling back to ODA FileConverter.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,7 +30,7 @@ flowchart TB
 | `beat` | `backend/app/tasks/cleanup.py` | Daily cleanup/archive scheduler. |
 | `postgres` | Docker image | Job metadata, config JSON, progress, errors, timestamps. |
 | `redis` | Docker image | Celery broker/result backend and progress Pub/Sub. |
-| `dwg-converter` | optional Compose profile | Placeholder sidecar for operator-supplied DWG tooling. |
+| `dwg-converter` | optional Compose profile | GNU LibreDWG sidecar that provides DXF→DWG conversion tooling (`dxf2dwg`, `dwgwrite`) via a shared volume. |
 
 ## Job lifecycle
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -45,6 +45,10 @@ Start optional DWG profile:
 make docker-up-dwg
 ```
 
+This profile now builds GNU LibreDWG from source and exports `/opt/libredwg`
+through a named volume. The runtime services mount that volume read-only and
+default `DWG_CONVERTER_COMMAND` to `dwgwrite {input} {output}`.
+
 ## ML model provisioning
 
 `backend/models/semantic_segmenter.onnx` ships a small reference model so the

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -139,4 +139,4 @@ Recommended lightweight open-source models for floor-plan segmentation:
 - True DWG generation is a post-processing conversion from DXF, not a native DWG writer.
 - The pipeline is synchronous inside a Celery task; parallel page processing is a future optimization.
 - **The bundled ML segmentation model is a reference implementation.** `backend/models/semantic_segmenter.onnx` is a small deterministic edge-energy model that satisfies the 5-class output contract but is not trained on floor plans. Swap in trained weights with `make download-model MODEL_URL=<url>` or `SEGMENTER_MODEL_URL`; artifacts are contract-validated on provisioning.
-- **DWG conversion requires an external binary.** The `dwg-converter` Compose profile is a placeholder. A `libredwg` sidecar Docker image (providing `dwgwrite`) should be built and wired into the profile for DXF→DWG support.
+- **DWG conversion is now sidecar-based.** The optional `dwg-converter` Compose profile builds GNU LibreDWG from source and shares `/opt/libredwg` with the runtime services. `DwgConverterStep` prefers LibreDWG's `dxf2dwg`, then `dwgwrite`, and finally ODA FileConverter if configured manually.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,7 +34,7 @@ The project has implemented the core proof-of-concept path:
 These are the critical blockers for production-quality conversion. See `TODO.md` Stage 6 for user stories.
 
 - **Host trained weights for the floor-plan segmentation model.** US-029 bundled a contract-compliant reference ONNX model at `backend/models/semantic_segmenter.onnx` plus the validated acquisition path (`make download-model MODEL_URL=<url>` / `SEGMENTER_MODEL_URL`). The remaining step is selecting and hosting trained weights (e.g. CubiCasa5K SegFormer or FloorPlan-Segmentation-UNet converted to the segmenter's single-channel 5-class contract) for production accuracy.
-- **Build a `libredwg` Docker sidecar** providing the `dwgwrite` binary for DXF→DWG conversion. The `dwg-converter` Compose profile is currently a placeholder alpine image.
+- **Benchmark the GNU LibreDWG sidecar on larger drawings and alternative DWG targets.** US-032 now provides a working DXF→DWG sidecar; the next step is operational benchmarking and deciding whether additional converter targets (e.g. newer DWG revisions via other tooling) are needed.
 - **Swap the reference model for trained weights and benchmark accuracy.** US-031 proved the 5-label contract, input-size compatibility checks, and DXF layer plumbing using the bundled deterministic reference model. The next step is hosting trained weights and benchmarking them against architectural drawings.
 
 ### Conversion quality


### PR DESCRIPTION
- Implements US-032 (Stage 6, Epic 6.3 — DWG Converter Sidecar).

- Adds `backend/Dockerfile.libredwg` to build GNU LibreDWG 0.13.3 from official source.

- Replaces the placeholder `dwg-converter` Compose profile with a real LibreDWG sidecar.

- Exports `/opt/libredwg` via a shared named volume mounted by backend/worker/beat.

- Auto-configures `DWG_CONVERTER_COMMAND='dwgwrite {input} {output}'`.

- Updates `DwgConverterStep` to prefer LibreDWG’s official DXF→DWG tools (`dxf2dwg`, then `dwgwrite`) before ODA fallback.

- Adds structural Compose tests plus end-to-end DWG conversion tests, including an opt-in real Docker/libredwg smoke test.

- Docs updated and US-032 marked __In Review__.

Closes #52 