### PR TITLE
feat(ml): add Yytsi Torch segmenter backend and Docker runtime wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,18 +9,17 @@ REDIS_URL=redis://localhost:6379/0
 STORAGE_PATH=./storage
 STORAGE_TTL_DAYS=7
 MODELS_PATH=./models
-# ML segmentation model (US-030). SEGMENTER_MODEL_PATH resolves relative to
-# the backend working directory: backend/models locally, /app/models in Docker.
-SEGMENTER_MODEL_PATH=./models/semantic_segmenter.onnx
-# Auto-download fallback used when the model file above is missing (e.g. a
-# fresh Docker models volume). Points at the reference model committed to this
-# repository; replace with hosted trained weights when available.
-SEGMENTER_MODEL_URL=https://raw.githubusercontent.com/Josh-Uvi/DrawLift/main/backend/models/semantic_segmenter.onnx
-# ONNX input resolution side length in pixels (default 128). The bundled
-# reference model accepts any size; a fixed-resolution trained model (e.g.
-# 256x256 for a CubiCasa5K SegFormer export) must match its declared input
-# dimensions exactly. `make validate-model` verifies the configured value.
-SEGMENTER_MODEL_INPUT_SIZE=128
+# ML segmentation model bundle (Yytsi Torch path). SEGMENTER_MODEL_PATH and
+# SEGMENTER_MODEL_CONFIG_PATH resolve relative to the backend working
+# directory: backend/models locally, /app/models in Docker.
+SEGMENTER_MODEL_PATH=./models/best.safetensors
+SEGMENTER_MODEL_CONFIG_PATH=./models/config.yaml
+# Auto-download fallbacks used when the model bundle above is missing (e.g. a
+# fresh Docker models volume).
+SEGMENTER_MODEL_URL=https://huggingface.co/Yytsi/floorplan-to-3d-walls/resolve/main/best.safetensors
+SEGMENTER_MODEL_CONFIG_URL=https://huggingface.co/Yytsi/floorplan-to-3d-walls/resolve/main/config.yaml
+# The published Yytsi bundle is configured for 512x512 inputs.
+SEGMENTER_MODEL_INPUT_SIZE=512
 CORS_ORIGINS=["http://localhost:3000"]
 DEBUG=true
 
@@ -34,7 +33,7 @@ DEBUG=true
 JOB_STALE_TIMEOUT_SECONDS=300
 
 # Docker worker memory limits (used by docker-compose.yml).
-# Increase these if the ONNX segmentation model + image pipeline triggers OOM.
+# Increase these if the Torch segmentation model + image pipeline triggers OOM.
 # WORKER_MEM_LIMIT=4g
 # WORKER_MEMSWAP_LIMIT=6g
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,12 +15,26 @@ repos:
 
       - id: frontend-eslint
         name: Frontend lint (ESLint)
-        entry: bash -c 'cd frontend && npm run lint'
+        entry: >-
+          bash -c 'cd frontend && created=0;
+          if [ ! -d node_modules ]; then npm ci --no-audit --no-fund && created=1; fi;
+          npm run lint;
+          status=$?;
+          if [ "$created" -eq 1 ]; then rm -rf node_modules; fi;
+          exit $status'
         language: system
         pass_filenames: false
+        require_serial: true
 
       - id: frontend-prettier
         name: Frontend format check (Prettier)
-        entry: bash -c 'cd frontend && npm run format:check'
+        entry: >-
+          bash -c 'cd frontend && created=0;
+          if [ ! -d node_modules ]; then npm ci --no-audit --no-fund && created=1; fi;
+          npm run format:check;
+          status=$?;
+          if [ "$created" -eq 1 ]; then rm -rf node_modules; fi;
+          exit $status'
         language: system
         pass_filenames: false
+        require_serial: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,9 @@ repos:
         name: Frontend lint (ESLint)
         entry: >-
           bash -c 'cd frontend && created=0;
-          if [ ! -d node_modules ]; then npm ci --no-audit --no-fund && created=1; fi;
+          if [ ! -x node_modules/.bin/eslint ] || [ ! -x node_modules/.bin/prettier ]; then
+            npm ci --no-audit --no-fund && created=1;
+          fi;
           npm run lint;
           status=$?;
           if [ "$created" -eq 1 ]; then rm -rf node_modules; fi;
@@ -30,7 +32,9 @@ repos:
         name: Frontend format check (Prettier)
         entry: >-
           bash -c 'cd frontend && created=0;
-          if [ ! -d node_modules ]; then npm ci --no-audit --no-fund && created=1; fi;
+          if [ ! -x node_modules/.bin/prettier ] || [ ! -x node_modules/.bin/eslint ]; then
+            npm ci --no-audit --no-fund && created=1;
+          fi;
           npm run format:check;
           status=$?;
           if [ "$created" -eq 1 ]; then rm -rf node_modules; fi;

--- a/.talismanrc
+++ b/.talismanrc
@@ -2,7 +2,7 @@ fileignoreconfig:
 - filename: .github/workflows/project-sync.yml
   checksum: f817f70193e5d38e8b49f7a2b79f79e6ad840d79ad0079b936760cdb3c22109
 - filename: .env.example
-  checksum: 1e0cd1877f68cc815416d317b61610f15daaead9fc4503869bdd1b5b2325348f
+  checksum: 23b408e452cfc4356275da395246166006df086c276f6d1f956a9f8033f9a757
 - filename: backend/alembic/env.py
   checksum: 36268371600cb457e610eb2625a5a5225deace0d05a550e25ab848d84ec52af0
 - filename: backend/alembic.ini
@@ -12,7 +12,7 @@ fileignoreconfig:
 - filename: frontend/package-lock.json
   checksum: 9abe9b9e245be5f3bde7e5df87c0ee67ec7152bbd879393c48c70dc0f43cddd1
 - filename: docs/TODO.md
-  checksum: c146fa4c1bd6258da9ee45111908a177a1b39553b9e70e07d86927fe17221c0e
+  checksum: 5d9f583d64bd16085685dab2b64155c145a12bfe62eab38dd0ab0132e77d4c38
 - filename: backend/app/api/v1/jobs_stream.py
   checksum: 6e6a351f846e5d70ba0879f6f78dc97b9ce7cff45062aa5e5c6492a7b062dfbc
 - filename: frontend/src/components/job/PageViewer.tsx
@@ -34,23 +34,25 @@ fileignoreconfig:
 - filename: backend/tests/test_placeholder_task_paths.py
   checksum: 9d4d13e1fb42553059aa323251d2b7e31f89c2c653a8fabaf3de5f6e6a9dfe94
 - filename: README.md
-  checksum: 025d08ffdf0f2d390d71f80b2e443fb58bc703739af104d221f5a41c7a03ee65
+  checksum: 14bbcd6830c9fa5cc57d64e4f0c3505652030d071017ef15bdb7d78baaa7ffc4
 - filename: backend/tests/test_stale_job_recovery.py
   checksum: f3509c5c0e6b1b93691a00c5643a07deb30cc91565266c408a487f52491e4774
 - filename: backend/tests/test_celery_worker_config.py
   checksum: c67ee5a15fb093dc5f20a535ba7d24aacd8209eb7ff57f8eafd086d66af40866
 - filename: backend/tests/test_model_provisioning.py
-  checksum: 41c2ce7ac8ef945aab87bdf317c79798279123fe52746540b35c5ba7c95d2863
+  checksum: 2d1b5f72cb3ab2d1ed19f5291b06bde6a7fc70958a31a6522bc5c7deb8ea14da
 - filename: backend/tests/test_ml_five_class_pipeline.py
-  checksum: bc4fe4dea10ff26a20d62139114fdf4f98e70ef78c64fbb0e67a46141326bed8
+  checksum: 535f97aa4517dae9dac2bd389ea8ef29507be026ee9727bbfe1a9ad0c1c4f80d
 - filename: backend/tests/test_segmenter_comparison.py
   checksum: f916b174c044decb22ba28ddbf4509084acc333f83f7280599830fcad08bd811
 - filename: backend/app/ml/download_model.py
-  checksum: 9c4f4e4cd82aa01fa78ae9d4498e352bce2b3dd62c9b5289f4f860855aed130a
+  checksum: 1c0253b6101c4b2e3cf1ef6b05db89937793300998e315d0ecf5ba79f070d8bf
 - filename: backend/tests/test_model_env_wiring.py
-  checksum: 896deca5abe0924e0dba7acb9cce21a983822a7a3482824868d99957d0d967fa
+  checksum: 9b401e423c4597d158b7913d894ff150ecb94c2a2a278e7b450633343080c4a9
 - filename: backend/tests/test_worker_model_preload.py
-  checksum: 90abfb7d2bf5c5979c6f86ad7de1d99db391aa12bbb849d3b77b79e9d215624f
+  checksum: 96f99b4c1cb4c69782dec2b9506ee64d30ab69f9352f95e66ac7bd0d17a27a0e
 - filename: backend/tests/test_ml_segmenter_wiring.py
-  checksum: 824be92578d3034783c7d0d37380a407500dcf9c9aede30eacaef311ccc2c885
+  checksum: e29427637656ff391de12b119b7a2182cfe750093383792a32b16fae9ec9ef95
+- filename: backend/tests/test_yytsi_torch_segmenter.py
+  checksum: c2f4ac962c1696b33c3cb4a8d83c1bb7987cd3c0797640c7ed8d6c804b552e71
 version: "1.0"

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ cp .env.example .env
 
 The default Docker Compose stack uses PostgreSQL, Redis, local storage volumes, and `NEXT_PUBLIC_API_URL=http://localhost:8000`.
 
+The default ML runtime now targets the `Yytsi/floorplan-to-3d-walls` Torch
+bundle (`best.safetensors` + `config.yaml`). On a fresh Docker models volume,
+the backend/worker auto-download the bundle and preload the configured ML
+backend at worker startup.
+
 ### All-Docker quick start
 
 ```bash
@@ -203,6 +208,10 @@ cd ../frontend
 npm run lint
 npm run format:check
 npm run build
+
+# root hooks (frontend deps auto-bootstrap if missing)
+cd ..
+pre-commit run --all-files
 ```
 
 Root service commands:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies
+# Install Python dependencies, including the CPU Torch inference stack used by
+# the Yytsi `.safetensors + config.yaml` segmentation bundle.
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -28,6 +28,8 @@ class Settings(BaseSettings):
     MODELS_PATH: str = "./models"
     SEGMENTER_MODEL_PATH: str | None = None
     SEGMENTER_MODEL_URL: str | None = None
+    SEGMENTER_MODEL_CONFIG_PATH: str | None = None
+    SEGMENTER_MODEL_CONFIG_URL: str | None = None
     SEGMENTER_MODEL_INPUT_SIZE: int = 128
 
     # CORS

--- a/backend/app/ml/__init__.py
+++ b/backend/app/ml/__init__.py
@@ -13,6 +13,17 @@ from app.ml.segmentation_model import (
     provision_segmentation_model,
     validate_segmentation_model,
 )
+from app.ml.yytsi_torch import (
+    YYTSI_CONFIG_FILENAME,
+    YYTSI_CONFIG_URL,
+    YYTSI_MODEL_FILENAME,
+    YYTSI_MODEL_URL,
+    YytsiBundleValidationReport,
+    infer_yytsi_config_url,
+    load_yytsi_config,
+    resolve_yytsi_model_assets,
+    validate_yytsi_bundle,
+)
 
 __all__ = [
     "MAX_MODEL_SIZE_BYTES",
@@ -26,4 +37,13 @@ __all__ = [
     "download_segmentation_model",
     "provision_segmentation_model",
     "validate_segmentation_model",
+    "YYTSI_CONFIG_FILENAME",
+    "YYTSI_CONFIG_URL",
+    "YYTSI_MODEL_FILENAME",
+    "YYTSI_MODEL_URL",
+    "YytsiBundleValidationReport",
+    "infer_yytsi_config_url",
+    "load_yytsi_config",
+    "resolve_yytsi_model_assets",
+    "validate_yytsi_bundle",
 ]

--- a/backend/app/ml/download_model.py
+++ b/backend/app/ml/download_model.py
@@ -27,6 +27,11 @@ from app.ml.segmentation_model import (
     provision_segmentation_model,
     validate_segmentation_model,
 )
+from app.ml.yytsi_torch import (
+    YYTSI_CONFIG_FILENAME,
+    resolve_yytsi_model_assets,
+    validate_yytsi_bundle,
+)
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
@@ -49,6 +54,16 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "--filename",
         default=SEGMENTATION_MODEL_FILENAME,
         help=f"Model file name (default: {SEGMENTATION_MODEL_FILENAME})",
+    )
+    parser.add_argument(
+        "--config-filename",
+        default=YYTSI_CONFIG_FILENAME,
+        help=f"Companion config filename for multi-file bundles (default: {YYTSI_CONFIG_FILENAME})",
+    )
+    parser.add_argument(
+        "--config-url",
+        default=None,
+        help="Optional config download URL for multi-file model bundles",
     )
     parser.add_argument(
         "--force",
@@ -75,21 +90,53 @@ def main(argv: Sequence[str] | None = None) -> int:
     settings = get_settings()
     models_dir = Path(args.models_dir) if args.models_dir else Path(settings.MODELS_PATH)
     destination = models_dir / args.filename
+    config_destination = models_dir / args.config_filename
+
+    is_yytsi_bundle = destination.suffix.lower() == ".safetensors"
 
     if args.check:
-        report = validate_segmentation_model(destination, probe_size=args.probe_size)
-        print(report.summary())
+        if is_yytsi_bundle:
+            yytsi_report = validate_yytsi_bundle(
+                weights_path=destination,
+                config_path=config_destination,
+                input_size=settings.SEGMENTER_MODEL_INPUT_SIZE,
+            )
+            print(yytsi_report.summary())
+            print("result: PASS" if yytsi_report.passed else "result: FAIL")
+            return 0 if yytsi_report.passed else 1
+        onnx_report = validate_segmentation_model(destination, probe_size=args.probe_size)
+        print(onnx_report.summary())
         input_size_report = check_model_input_size(destination, settings.SEGMENTER_MODEL_INPUT_SIZE)
         configured_size = settings.SEGMENTER_MODEL_INPUT_SIZE
         print(
             f"input size: ({configured_size}, {configured_size}) — " f"{input_size_report.reason}"
         )
-        passed = report.passed and input_size_report.compatible
+        passed = onnx_report.passed and input_size_report.compatible
         print("result: PASS" if passed else "result: FAIL")
         return 0 if passed else 1
 
     model_url = args.url or settings.SEGMENTER_MODEL_URL
     try:
+        if is_yytsi_bundle:
+            if args.force:
+                destination.unlink(missing_ok=True)
+                config_destination.unlink(missing_ok=True)
+            path, config_path = resolve_yytsi_model_assets(
+                model_path=destination,
+                config_path=config_destination,
+                model_url=model_url,
+                config_url=args.config_url or settings.SEGMENTER_MODEL_CONFIG_URL,
+            )
+            yytsi_report = validate_yytsi_bundle(
+                weights_path=path,
+                config_path=config_path,
+                input_size=settings.SEGMENTER_MODEL_INPUT_SIZE,
+            )
+            if not yytsi_report.passed:
+                raise ModelProvisioningError(yytsi_report.summary())
+            print(yytsi_report.summary())
+            print(f"result: PASS — model provisioned at {path}")
+            return 0
         path = provision_segmentation_model(
             destination,
             model_url=model_url,
@@ -100,8 +147,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
-    report = validate_segmentation_model(path, probe_size=args.probe_size)
-    print(report.summary())
+    onnx_report = validate_segmentation_model(path, probe_size=args.probe_size)
+    print(onnx_report.summary())
     print(f"result: PASS — model provisioned at {path}")
     return 0
 

--- a/backend/app/ml/yytsi_torch.py
+++ b/backend/app/ml/yytsi_torch.py
@@ -1,0 +1,391 @@
+"""Torch-backed floor-plan segmenter for `Yytsi/floorplan-to-3d-walls`.
+
+This backend consumes the published Hugging Face `best.safetensors` +
+`config.yaml` bundle and preserves the existing 5-label contract expected by
+the rest of the pipeline:
+
+* `walls`, `doors`, `windows` come from the 4-class structural model.
+* `rooms` are derived from the predicted structural masks.
+* `text` is provisioned heuristically from residual foreground in the
+  preprocessed page image, so downstream DXF layers and UI previews keep the
+  same stable label set.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+import cv2
+import numpy as np
+import yaml  # type: ignore[import-untyped]
+
+from app.ml.segmentation_model import download_segmentation_model
+
+YYTSI_MODEL_FILENAME = "best.safetensors"
+YYTSI_CONFIG_FILENAME = "config.yaml"
+YYTSI_MODEL_URL = "https://huggingface.co/Yytsi/floorplan-to-3d-walls/resolve/main/best.safetensors"
+YYTSI_CONFIG_URL = "https://huggingface.co/Yytsi/floorplan-to-3d-walls/resolve/main/config.yaml"
+
+YYTSI_CLASS_NAMES: tuple[str, ...] = ("floor", "wall", "door", "window")
+YYTSI_CLASS_TO_ID = {name: index for index, name in enumerate(YYTSI_CLASS_NAMES)}
+YYTSI_NUM_CLASSES = len(YYTSI_CLASS_NAMES)
+YYTSI_IMAGENET_MEAN = (0.485, 0.456, 0.406)
+YYTSI_IMAGENET_STD = (0.229, 0.224, 0.225)
+YYTSI_MEAN_RGB_255 = tuple(int(round(channel * 255)) for channel in YYTSI_IMAGENET_MEAN)
+
+MIN_TEXT_COMPONENT_AREA = 8
+MAX_TEXT_COMPONENT_AREA = 3_000
+MAX_TEXT_DIMENSION_RATIO = 0.35
+TEXT_DILATION_KERNEL = np.ones((3, 3), dtype=np.uint8)
+STRUCTURE_DILATION_KERNEL = np.ones((5, 5), dtype=np.uint8)
+
+
+@dataclass(frozen=True)
+class YytsiModelConfig:
+    """Runtime-relevant subset of the upstream `config.yaml`."""
+
+    image_size: tuple[int, int]
+    normalize: bool
+    letterbox: bool
+    encoder_name: str
+    encoder_weights: str | None
+
+
+@dataclass(frozen=True)
+class YytsiBundleValidationReport:
+    """Validation result for a Yytsi weights+config bundle."""
+
+    weights_path: Path
+    config_path: Path
+    image_size: tuple[int, int] | None = None
+    class_names: tuple[str, ...] = YYTSI_CLASS_NAMES
+    loads_on_cpu: bool = False
+    inference_ok: bool = False
+    contract_ok: bool = False
+    errors: tuple[str, ...] = ()
+
+    @property
+    def passed(self) -> bool:
+        return not self.errors
+
+    def summary(self) -> str:
+        size = self.image_size if self.image_size is not None else "n/a"
+        lines = [
+            f"weights path:   {self.weights_path}",
+            f"config path:    {self.config_path}",
+            f"image size:     {size}",
+            f"classes:        {', '.join(self.class_names)}",
+            f"cpu load:       {self.loads_on_cpu}",
+            f"inference:      {'ok' if self.inference_ok else 'failed'}",
+            f"5-class bridge: {'ok' if self.contract_ok else 'failed'}",
+        ]
+        if self.errors:
+            lines.append("errors:")
+            lines.extend(f"  - {error}" for error in self.errors)
+        return "\n".join(lines)
+
+
+def infer_yytsi_config_url(model_url: str) -> str:
+    """Infer the companion config URL from a published weights URL."""
+    if model_url.endswith(YYTSI_MODEL_FILENAME):
+        return model_url[: -len(YYTSI_MODEL_FILENAME)] + YYTSI_CONFIG_FILENAME
+    return YYTSI_CONFIG_URL
+
+
+def resolve_yytsi_model_assets(
+    *,
+    model_path: Path | str,
+    config_path: Path | str | None = None,
+    model_url: str | None = None,
+    config_url: str | None = None,
+) -> tuple[Path, Path]:
+    """Resolve/download the Yytsi weights and config bundle."""
+    weights_path = Path(model_path).expanduser().resolve()
+    resolved_config_path = (
+        Path(config_path).expanduser().resolve()
+        if config_path is not None
+        else weights_path.with_name(YYTSI_CONFIG_FILENAME)
+    )
+
+    if not weights_path.exists():
+        download_segmentation_model(model_url or YYTSI_MODEL_URL, weights_path)
+    if not resolved_config_path.exists():
+        download_segmentation_model(
+            config_url or infer_yytsi_config_url(model_url or YYTSI_MODEL_URL),
+            resolved_config_path,
+        )
+    return weights_path, resolved_config_path
+
+
+def load_yytsi_config(config_path: Path | str) -> YytsiModelConfig:
+    """Load the upstream YAML config used by the published weights."""
+    raw = yaml.safe_load(Path(config_path).read_text())
+    if not isinstance(raw, dict):
+        raise ValueError("Yytsi config.yaml must deserialize to a mapping")
+    data = raw.get("data", {})
+    model = raw.get("model", {})
+    if not isinstance(data, dict) or not isinstance(model, dict):
+        raise ValueError("Yytsi config.yaml is missing the `data` or `model` section")
+
+    image_size = data.get("image_size", [512, 512])
+    if not isinstance(image_size, Sequence) or len(image_size) != 2:
+        raise ValueError("Yytsi config.yaml must define data.image_size as [H, W]")
+
+    encoder_weights = model.get("encoder_weights")
+    if encoder_weights is not None and not isinstance(encoder_weights, str):
+        raise ValueError("Yytsi config.yaml model.encoder_weights must be a string or null")
+
+    return YytsiModelConfig(
+        image_size=(int(image_size[0]), int(image_size[1])),
+        normalize=bool(data.get("normalize", True)),
+        letterbox=bool(data.get("letterbox", True)),
+        encoder_name=str(model.get("encoder_name", "resnet34")),
+        encoder_weights=encoder_weights,
+    )
+
+
+def validate_yytsi_bundle(
+    *,
+    weights_path: Path | str,
+    config_path: Path | str,
+    input_size: tuple[int, int] | int | None = None,
+) -> YytsiBundleValidationReport:
+    """Validate the Yytsi weights/config bundle for CPU inference use."""
+    import torch
+
+    resolved_weights = Path(weights_path).expanduser().resolve()
+    resolved_config = Path(config_path).expanduser().resolve()
+    errors: list[str] = []
+    if not resolved_weights.is_file():
+        errors.append(f"weights file not found: {resolved_weights}")
+    if not resolved_config.is_file():
+        errors.append(f"config file not found: {resolved_config}")
+    if errors:
+        return YytsiBundleValidationReport(
+            weights_path=resolved_weights,
+            config_path=resolved_config,
+            errors=tuple(errors),
+        )
+
+    config = load_yytsi_config(resolved_config)
+    requested_size = (
+        config.image_size
+        if input_size is None
+        else ((input_size, input_size) if isinstance(input_size, int) else input_size)
+    )
+    if tuple(requested_size) != tuple(config.image_size):
+        errors.append(
+            f"configured input size {requested_size[0]}x{requested_size[1]} does not match "
+            f"bundle config {config.image_size[0]}x{config.image_size[1]}"
+        )
+
+    try:
+        model = get_yytsi_model(str(resolved_weights), str(resolved_config))
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"failed to load Torch model bundle: {exc}")
+        return YytsiBundleValidationReport(
+            weights_path=resolved_weights,
+            config_path=resolved_config,
+            image_size=config.image_size,
+            errors=tuple(errors),
+        )
+
+    inference_ok = False
+    contract_ok = False
+    try:
+        sample = torch.zeros(
+            (1, 3, config.image_size[0], config.image_size[1]),
+            dtype=torch.float32,
+        )
+        logits = model(sample)
+        expected_shape = (
+            1,
+            YYTSI_NUM_CLASSES,
+            config.image_size[0],
+            config.image_size[1],
+        )
+        if tuple(logits.shape) != expected_shape:
+            errors.append(
+                f"unexpected logits shape {tuple(logits.shape)} for image size {config.image_size}"
+            )
+        else:
+            inference_ok = True
+            contract_ok = True
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"Torch inference failed: {exc}")
+
+    return YytsiBundleValidationReport(
+        weights_path=resolved_weights,
+        config_path=resolved_config,
+        image_size=config.image_size,
+        loads_on_cpu=True,
+        inference_ok=inference_ok,
+        contract_ok=contract_ok and not errors,
+        errors=tuple(errors),
+    )
+
+
+@lru_cache(maxsize=1)
+def get_yytsi_model(weights_path: str, config_path: str):
+    """Load the published Yytsi segmentation model into process-local cache."""
+    import segmentation_models_pytorch as smp
+    from safetensors.torch import load_file
+
+    config = load_yytsi_config(config_path)
+    model = smp.Unet(
+        encoder_name=config.encoder_name,
+        encoder_weights=config.encoder_weights,
+        in_channels=3,
+        classes=YYTSI_NUM_CLASSES,
+    )
+    state_dict = load_file(str(weights_path), device="cpu")
+    model.load_state_dict(state_dict, strict=True)
+    model.eval()
+    return model
+
+
+def prepare_yytsi_input(
+    image: np.ndarray,
+    *,
+    image_size: tuple[int, int],
+    normalize: bool,
+    letterbox: bool,
+) -> tuple[np.ndarray, tuple[int, int, int, int]]:
+    """Convert a grayscale/binary page image into model-ready RGB CHW float32.
+
+    Returns `(tensor_chw, content_rect)` where `content_rect` is
+    `(left, top, inner_w, inner_h)` in the letterboxed canvas.
+    """
+    grayscale = _to_grayscale(image)
+    binary = (grayscale > 0).astype(np.uint8)
+    height, width = image_size
+
+    if letterbox:
+        scale = min(width / grayscale.shape[1], height / grayscale.shape[0])
+        inner_w = max(1, int(round(grayscale.shape[1] * scale)))
+        inner_h = max(1, int(round(grayscale.shape[0] * scale)))
+    else:
+        inner_w, inner_h = width, height
+
+    rgb = np.full((inner_h, inner_w, 3), YYTSI_MEAN_RGB_255, dtype=np.uint8)
+    resized = cv2.resize(binary, (inner_w, inner_h), interpolation=cv2.INTER_AREA)
+    rgb[resized > 0] = (0, 0, 0)
+
+    top = (height - inner_h) // 2
+    left = (width - inner_w) // 2
+    canvas = np.full((height, width, 3), YYTSI_MEAN_RGB_255, dtype=np.uint8)
+    canvas[top : top + inner_h, left : left + inner_w] = rgb
+
+    tensor = canvas.astype(np.float32) / np.float32(255.0)
+    if normalize:
+        mean = np.asarray(YYTSI_IMAGENET_MEAN, dtype=np.float32).reshape(1, 1, 3)
+        std = np.asarray(YYTSI_IMAGENET_STD, dtype=np.float32).reshape(1, 1, 3)
+        tensor = (tensor - mean) / std
+    chw = np.moveaxis(tensor, -1, 0)
+    return chw, (left, top, inner_w, inner_h)
+
+
+def decode_yytsi_predictions(
+    *,
+    class_map: np.ndarray,
+    original_image: np.ndarray,
+    original_shape: tuple[int, int],
+    content_rect: tuple[int, int, int, int],
+    mask_labels: Sequence[str],
+) -> dict[str, list[np.ndarray]]:
+    """Convert the 4-class Yytsi output into the pipeline's 5-label contract."""
+    left, top, inner_w, inner_h = content_rect
+    crop = class_map[top : top + inner_h, left : left + inner_w]
+    resized_class_map = cv2.resize(
+        crop.astype(np.uint8),
+        (original_shape[1], original_shape[0]),
+        interpolation=cv2.INTER_NEAREST,
+    )
+
+    masks: dict[str, list[np.ndarray]] = {label: [] for label in mask_labels}
+    wall_mask = (resized_class_map == YYTSI_CLASS_TO_ID["wall"]).astype(np.uint8) * 255
+    door_mask = (resized_class_map == YYTSI_CLASS_TO_ID["door"]).astype(np.uint8) * 255
+    window_mask = (resized_class_map == YYTSI_CLASS_TO_ID["window"]).astype(np.uint8) * 255
+    floor_mask = (resized_class_map == YYTSI_CLASS_TO_ID["floor"]).astype(np.uint8) * 255
+    room_mask = derive_room_mask(floor_mask, wall_mask, door_mask, window_mask)
+    text_mask = detect_text_regions(original_image, wall_mask, door_mask, window_mask)
+
+    masks["walls"].append(wall_mask)
+    masks["doors"].append(door_mask)
+    masks["windows"].append(window_mask)
+    masks["rooms"].append(room_mask)
+    masks["text"].append(text_mask)
+    return masks
+
+
+def derive_room_mask(
+    floor_mask: np.ndarray,
+    wall_mask: np.ndarray,
+    door_mask: np.ndarray,
+    window_mask: np.ndarray,
+) -> np.ndarray:
+    """Derive room regions from structural masks while keeping interior floor."""
+    structure = cv2.bitwise_or(wall_mask, cv2.bitwise_or(door_mask, window_mask))
+    sealed_walls = cv2.morphologyEx(wall_mask, cv2.MORPH_CLOSE, STRUCTURE_DILATION_KERNEL)
+    candidate_rooms = cv2.bitwise_not(sealed_walls)
+    height, width = candidate_rooms.shape
+    flood_filled = candidate_rooms.copy()
+    flood_mask = np.zeros((height + 2, width + 2), dtype=np.uint8)
+    cv2.floodFill(flood_filled, flood_mask, (0, 0), 0)
+    rooms = cv2.bitwise_and(flood_filled, floor_mask)
+    rooms = cv2.bitwise_and(rooms, cv2.bitwise_not(structure))
+    return cv2.morphologyEx(rooms, cv2.MORPH_OPEN, TEXT_DILATION_KERNEL)
+
+
+def detect_text_regions(
+    image: np.ndarray,
+    wall_mask: np.ndarray,
+    door_mask: np.ndarray,
+    window_mask: np.ndarray,
+) -> np.ndarray:
+    """Heuristically recover text regions from residual page foreground."""
+    grayscale = _to_grayscale(image)
+    foreground = ((grayscale > 0).astype(np.uint8)) * 255
+    structure = cv2.bitwise_or(wall_mask, cv2.bitwise_or(door_mask, window_mask))
+    structure_buffer = cv2.dilate(structure, STRUCTURE_DILATION_KERNEL)
+    residual = cv2.bitwise_and(
+        foreground,
+        cv2.bitwise_not(structure_buffer),
+    )
+
+    component_count, labels, stats, _centroids = cv2.connectedComponentsWithStats(
+        (residual > 0).astype(np.uint8), connectivity=8
+    )
+    text_mask = np.zeros_like(foreground, dtype=np.uint8)
+    max_width = residual.shape[1] * MAX_TEXT_DIMENSION_RATIO
+    max_height = residual.shape[0] * MAX_TEXT_DIMENSION_RATIO
+    for component_index in range(1, component_count):
+        area = int(stats[component_index, cv2.CC_STAT_AREA])
+        width = int(stats[component_index, cv2.CC_STAT_WIDTH])
+        height = int(stats[component_index, cv2.CC_STAT_HEIGHT])
+        if area < MIN_TEXT_COMPONENT_AREA or area > MAX_TEXT_COMPONENT_AREA:
+            continue
+        if width <= 1 or height <= 1:
+            continue
+        if width > max_width or height > max_height:
+            continue
+        text_mask[labels == component_index] = 255
+    return cv2.dilate(text_mask, TEXT_DILATION_KERNEL)
+
+
+def _to_grayscale(image: np.ndarray) -> np.ndarray:
+    """Convert a supported OpenCV image array to grayscale."""
+    if image.ndim == 2:
+        return image
+    if image.ndim != 3:
+        raise ValueError("Segmenter expects a 2D or 3D image array")
+    if image.shape[2] == 3:
+        return cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    if image.shape[2] == 4:
+        return cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
+    if image.shape[2] == 1:
+        return image[:, :, 0]
+    raise ValueError("Segmenter expects 1, 3, or 4 image channels")

--- a/backend/app/pipeline/__init__.py
+++ b/backend/app/pipeline/__init__.py
@@ -23,15 +23,18 @@ from app.pipeline.steps.glb_writer import GlbWriterStep
 from app.pipeline.steps.pdf_parser import PdfParserStep
 from app.pipeline.steps.preprocessor import OpenCVPreprocessor
 from app.pipeline.steps.segmenter import (
+    AutoMlSegmenter,
     ClassicCVSegmenter,
     OnnxSemanticSegmenter,
     SegmenterStep,
+    TorchYytsiSegmenter,
     preload_configured_segmentation_model,
 )
 from app.pipeline.steps.vectorizer import VectorizerStep
 
 __all__ = [
     "ClassicCVSegmenter",
+    "AutoMlSegmenter",
     "DxfWriterStep",
     "DwgConverterStep",
     "GlbWriterStep",
@@ -50,6 +53,7 @@ __all__ = [
     "Point3D",
     "RoomPrimitive",
     "SegmenterStep",
+    "TorchYytsiSegmenter",
     "SlabGenerator",
     "SlabPrimitive",
     "TextPrimitive",

--- a/backend/app/pipeline/steps/segmenter.py
+++ b/backend/app/pipeline/steps/segmenter.py
@@ -15,6 +15,15 @@ from app.ml.segmentation_model import (
     SEGMENTATION_MODEL_FILENAME,
     download_segmentation_model,
 )
+from app.ml.yytsi_torch import (
+    YYTSI_CONFIG_FILENAME,
+    YYTSI_MODEL_FILENAME,
+    decode_yytsi_predictions,
+    get_yytsi_model,
+    load_yytsi_config,
+    prepare_yytsi_input,
+    resolve_yytsi_model_assets,
+)
 from app.pipeline.context import PipelineContext
 from app.pipeline.steps.base import PipelineStep
 
@@ -30,6 +39,10 @@ MaskPathMap = dict[str, list[Path]]
 
 class SemanticSegmenter(Protocol):
     """Protocol implemented by concrete semantic segmentation backends."""
+
+    def preload(self) -> None:
+        """Warm any process-local model/session cache."""
+        ...
 
     def segment(self, images: Sequence[np.ndarray]) -> SegmentationMasks:
         """Return per-label masks for every input image."""
@@ -245,6 +258,143 @@ class OnnxSemanticSegmenter:
         return masks
 
 
+class TorchYytsiSegmenter:
+    """Torch-backed segmenter for `Yytsi/floorplan-to-3d-walls` weights."""
+
+    def __init__(
+        self,
+        *,
+        model_path: Path | str | None = None,
+        model_url: str | None = None,
+        models_dir: Path | str | None = None,
+        input_size: tuple[int, int] | None = None,
+        config_path: Path | str | None = None,
+        config_url: str | None = None,
+    ) -> None:
+        self.model_path = Path(model_path) if model_path is not None else None
+        self.model_url = model_url
+        self.models_dir = Path(models_dir) if models_dir is not None else None
+        self.config_path = Path(config_path) if config_path is not None else None
+        self.config_url = config_url
+        self.input_size = input_size
+
+    def preload(self) -> None:
+        weights_path, config_path = self._resolve_assets()
+        get_yytsi_model(str(weights_path), str(config_path))
+
+    def segment(self, images: Sequence[np.ndarray]) -> SegmentationMasks:
+        if not images:
+            return _empty_mask_collection()
+
+        import torch
+
+        weights_path, config_path = self._resolve_assets()
+        config = load_yytsi_config(config_path)
+        image_size = self.input_size or config.image_size
+        model = get_yytsi_model(str(weights_path), str(config_path))
+
+        masks = _empty_mask_collection()
+        with torch.no_grad():
+            for image in images:
+                original_shape = image.shape[:2]
+                chw, rect = prepare_yytsi_input(
+                    image,
+                    image_size=image_size,
+                    normalize=config.normalize,
+                    letterbox=config.letterbox,
+                )
+                tensor = torch.from_numpy(chw).unsqueeze(0)
+                logits = model(tensor)
+                class_map = logits.argmax(dim=1).squeeze(0).to("cpu", torch.uint8).numpy()
+                page_masks = decode_yytsi_predictions(
+                    class_map=class_map,
+                    original_image=image,
+                    original_shape=original_shape,
+                    content_rect=rect,
+                    mask_labels=MASK_LABELS,
+                )
+                for label in MASK_LABELS:
+                    masks[label].extend(page_masks[label])
+        return masks
+
+    def _resolve_assets(self) -> tuple[Path, Path]:
+        settings = get_settings()
+        configured_path = self.model_path or _optional_path(settings.SEGMENTER_MODEL_PATH)
+        if configured_path is not None:
+            weights_path = configured_path.expanduser().resolve()
+        else:
+            model_dir = (self.models_dir or Path(settings.MODELS_PATH)).expanduser().resolve()
+            weights_path = model_dir / YYTSI_MODEL_FILENAME
+        configured_config_path = self.config_path or _optional_path(
+            settings.SEGMENTER_MODEL_CONFIG_PATH
+        )
+        config_path = (
+            configured_config_path.expanduser().resolve()
+            if configured_config_path is not None
+            else weights_path.with_name(YYTSI_CONFIG_FILENAME)
+        )
+        return resolve_yytsi_model_assets(
+            model_path=weights_path,
+            config_path=config_path,
+            model_url=self.model_url or settings.SEGMENTER_MODEL_URL,
+            config_url=self.config_url or settings.SEGMENTER_MODEL_CONFIG_URL,
+        )
+
+
+class AutoMlSegmenter:
+    """Dispatch to ONNX or Torch ML backends based on the configured model path."""
+
+    def __init__(
+        self,
+        *,
+        model_path: Path | str | None = None,
+        model_url: str | None = None,
+        models_dir: Path | str | None = None,
+        input_size: tuple[int, int] | None = None,
+    ) -> None:
+        self.model_path = Path(model_path) if model_path is not None else None
+        self.model_url = model_url
+        self.models_dir = Path(models_dir) if models_dir is not None else None
+        self.input_size = input_size
+
+    def preload(self) -> None:
+        self._backend().preload()
+
+    def segment(self, images: Sequence[np.ndarray]) -> SegmentationMasks:
+        return self._backend().segment(images)
+
+    def _backend(self) -> SemanticSegmenter:
+        model_path = self._resolve_model_path_hint()
+        suffix = model_path.suffix.lower()
+        if suffix == ".onnx":
+            return OnnxSemanticSegmenter(
+                model_path=model_path,
+                model_url=self.model_url,
+                models_dir=self.models_dir,
+                input_size=self.input_size,
+            )
+        if suffix == ".safetensors":
+            return TorchYytsiSegmenter(
+                model_path=model_path,
+                model_url=self.model_url,
+                models_dir=self.models_dir,
+                input_size=self.input_size,
+            )
+        raise ValueError(
+            f"Unsupported ML model type {model_path.suffix!r}; expected .onnx or .safetensors"
+        )
+
+    def _resolve_model_path_hint(self) -> Path:
+        settings = get_settings()
+        configured_path = self.model_path or _optional_path(settings.SEGMENTER_MODEL_PATH)
+        if configured_path is not None:
+            return configured_path.expanduser().resolve()
+        model_dir = (self.models_dir or Path(settings.MODELS_PATH)).expanduser().resolve()
+        if self.model_url and self.model_url.endswith(".safetensors"):
+            return model_dir / YYTSI_MODEL_FILENAME
+        return model_dir / DEFAULT_MODEL_FILENAME
+
+
 class SegmenterStep(PipelineStep):
     """Pipeline step that produces semantic masks from preprocessed pages."""
 
@@ -260,7 +410,7 @@ class SegmenterStep(PipelineStep):
     ) -> None:
         """Create the segmentation step with optional backend overrides."""
         self.output_dir = Path(output_dir) if output_dir is not None else None
-        self.ml_segmenter = ml_segmenter or OnnxSemanticSegmenter()
+        self.ml_segmenter = ml_segmenter or AutoMlSegmenter()
         self.classic_segmenter = classic_segmenter or ClassicCVSegmenter()
 
     def execute(self, context: PipelineContext) -> PipelineContext:
@@ -328,11 +478,11 @@ class SegmenterStep(PipelineStep):
 
 
 def preload_configured_segmentation_model() -> None:
-    """Preload the configured ONNX model once when a worker process starts."""
+    """Preload the configured ML model once when a worker process starts."""
     settings = get_settings()
     if settings.SEGMENTER_MODEL_PATH is None and settings.SEGMENTER_MODEL_URL is None:
         return
-    OnnxSemanticSegmenter().preload()
+    AutoMlSegmenter().preload()
 
 
 def _empty_mask_collection() -> SegmentationMasks:

--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -18,10 +18,10 @@ celery_app = Celery(
 
 @worker_process_init.connect
 def _preload_segmentation_model(**kwargs: object) -> None:
-    """Load the configured ONNX segmentation model once per worker process.
+    """Load the configured ML segmentation backend once per worker process.
 
     Surfaces model configuration errors at worker startup instead of on the
-    first conversion job, and avoids paying ONNX session construction cost on
+    first conversion job, and avoids paying model/session construction cost on
     every job. No-op when neither ``SEGMENTER_MODEL_PATH`` nor
     ``SEGMENTER_MODEL_URL`` is configured.
     """

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,6 +12,11 @@ opencv-python-headless==4.*
 numpy==2.*
 onnxruntime==1.*
 onnx==1.*
+torch==2.12.*
+torchvision==0.27.*
+segmentation-models-pytorch==0.5.*
+safetensors==0.8.*
+PyYAML==6.0.*
 ezdxf==1.*
 trimesh==4.*
 shapely==2.*

--- a/backend/tests/test_ml_five_class_pipeline.py
+++ b/backend/tests/test_ml_five_class_pipeline.py
@@ -28,7 +28,7 @@ from app.pipeline import (
     SegmenterStep,
     VectorizerStep,
 )
-from app.pipeline.steps.segmenter import MASK_LABELS, OnnxSemanticSegmenter
+from app.pipeline.steps.segmenter import MASK_LABELS, OnnxSemanticSegmenter, TorchYytsiSegmenter
 
 BACKEND_DIR = Path(__file__).resolve().parents[1]
 BUNDLED_MODEL_PATH = BACKEND_DIR / "models" / "semantic_segmenter.onnx"
@@ -151,6 +151,59 @@ def test_ml_masks_cover_all_five_labels_via_settings(
     for label in MASK_LABELS:
         assert masks[label][0].shape == (240, 320)
         assert np.count_nonzero(masks[label][0]) > 0, f"ML returned an empty {label} mask"
+
+
+def test_torch_ml_masks_cover_all_five_labels_via_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Settings-driven Torch segmenter covers all five labels with a Yytsi bundle."""
+    monkeypatch.setenv("SEGMENTER_MODEL_PATH", "/tmp/models/best.safetensors")
+    monkeypatch.setenv("SEGMENTER_MODEL_CONFIG_PATH", "/tmp/models/config.yaml")
+    get_settings.cache_clear()
+
+    class FakeModel:
+        def __call__(self, tensor: object):
+            import torch
+
+            shape = getattr(tensor, "shape")
+            _, _channels, height, width = shape
+            output = torch.zeros((1, 4, height, width), dtype=torch.float32)
+            output[:, 1, 30 : height - 30, 30:38] = 10.0
+            output[:, 1, 30 : height - 30, width - 38 : width - 30] = 10.0
+            output[:, 1, 30:38, 30 : width - 30] = 10.0
+            output[:, 1, height - 38 : height - 30, 30 : width - 30] = 10.0
+            output[:, 2, height // 2 : height // 2 + 20, width // 2 - 20 : width // 2 + 20] = 10.0
+            output[:, 3, 56:72, width // 2 : width // 2 + 70] = 10.0
+            return output
+
+    monkeypatch.setattr(
+        "app.pipeline.steps.segmenter.resolve_yytsi_model_assets",
+        lambda **_: (Path("/tmp/models/best.safetensors"), Path("/tmp/models/config.yaml")),
+    )
+    monkeypatch.setattr(
+        "app.pipeline.steps.segmenter.load_yytsi_config",
+        lambda _: type(
+            "Cfg",
+            (),
+            {
+                "image_size": (128, 128),
+                "normalize": True,
+                "letterbox": True,
+            },
+        )(),
+    )
+    monkeypatch.setattr("app.pipeline.steps.segmenter.get_yytsi_model", lambda *_: FakeModel())
+
+    try:
+        segmenter = TorchYytsiSegmenter()
+        masks = segmenter.segment([create_five_class_floor_plan()])
+    finally:
+        get_settings.cache_clear()
+
+    assert set(masks) == set(MASK_LABELS)
+    for label in MASK_LABELS:
+        assert masks[label][0].shape == (240, 320)
+        assert np.count_nonzero(masks[label][0]) > 0, f"Torch ML returned an empty {label} mask"
 
 
 def test_ml_pipeline_dxf_includes_door_window_text_entities(

--- a/backend/tests/test_ml_segmenter_wiring.py
+++ b/backend/tests/test_ml_segmenter_wiring.py
@@ -22,7 +22,12 @@ from app.pipeline import (
     PipelineContext,
     SegmenterStep,
 )
-from app.pipeline.steps.segmenter import MASK_LABELS, OnnxSemanticSegmenter
+from app.pipeline.steps.segmenter import (
+    MASK_LABELS,
+    AutoMlSegmenter,
+    OnnxSemanticSegmenter,
+    TorchYytsiSegmenter,
+)
 
 BACKEND_DIR = Path(__file__).resolve().parents[1]
 BUNDLED_MODEL_PATH = BACKEND_DIR / "models" / "semantic_segmenter.onnx"
@@ -161,3 +166,24 @@ def test_ml_segmenter_processes_multi_page_floor_plan_pdf(
         assert len(result.masks[label]) == 2
     assert np.count_nonzero(result.masks["walls"][0]) > 0
     assert np.count_nonzero(result.masks["walls"][1]) > 0
+
+
+def test_auto_ml_segmenter_selects_torch_backend_for_safetensors_path() -> None:
+    """AutoMlSegmenter dispatches `.safetensors` models to the Torch backend."""
+    backend = AutoMlSegmenter(model_path="/tmp/best.safetensors")._backend()
+
+    assert isinstance(backend, TorchYytsiSegmenter)
+
+
+def test_auto_ml_segmenter_selects_torch_backend_from_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Settings-driven `.safetensors` paths resolve to the Torch backend."""
+    monkeypatch.setenv("SEGMENTER_MODEL_PATH", "/tmp/models/best.safetensors")
+    get_settings.cache_clear()
+
+    try:
+        backend = AutoMlSegmenter()._backend()
+        assert isinstance(backend, TorchYytsiSegmenter)
+    finally:
+        get_settings.cache_clear()

--- a/backend/tests/test_model_env_wiring.py
+++ b/backend/tests/test_model_env_wiring.py
@@ -17,7 +17,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 COMPOSE_PATH = REPO_ROOT / "docker-compose.yml"
 ENV_EXAMPLE_PATH = REPO_ROOT / ".env.example"
 
-CONTAINER_MODEL_PATH_DEFAULT = "/app/models/semantic_segmenter.onnx"
+CONTAINER_MODEL_PATH_DEFAULT = "/app/models/best.safetensors"
+CONTAINER_CONFIG_PATH_DEFAULT = "/app/models/config.yaml"
 
 
 def _active_env_example_values() -> dict[str, str]:
@@ -43,7 +44,7 @@ def test_env_example_sets_segmenter_model_path() -> None:
     """AC: SEGMENTER_MODEL_PATH is set in .env.example for the bundled model."""
     values = _active_env_example_values()
 
-    assert values.get("SEGMENTER_MODEL_PATH") == "./models/semantic_segmenter.onnx"
+    assert values.get("SEGMENTER_MODEL_PATH") == "./models/best.safetensors"
 
 
 def test_env_example_sets_segmenter_model_url_fallback() -> None:
@@ -52,7 +53,17 @@ def test_env_example_sets_segmenter_model_url_fallback() -> None:
 
     model_url = values.get("SEGMENTER_MODEL_URL", "")
     assert model_url.startswith("https://")
-    assert model_url.endswith("semantic_segmenter.onnx")
+    assert model_url.endswith("best.safetensors")
+
+
+def test_env_example_sets_segmenter_model_config_bundle_values() -> None:
+    """Torch bundle defaults include an explicit companion config path and URL."""
+    values = _active_env_example_values()
+
+    assert values.get("SEGMENTER_MODEL_CONFIG_PATH") == "./models/config.yaml"
+    config_url = values.get("SEGMENTER_MODEL_CONFIG_URL", "")
+    assert config_url.startswith("https://")
+    assert config_url.endswith("config.yaml")
 
 
 @pytest.mark.parametrize("service_name", ["backend", "worker", "beat"])
@@ -62,11 +73,17 @@ def test_compose_services_configure_segmenter_model_env(service_name: str) -> No
 
     path_value = environment.get("SEGMENTER_MODEL_PATH", "")
     url_value = environment.get("SEGMENTER_MODEL_URL", "")
+    config_path_value = environment.get("SEGMENTER_MODEL_CONFIG_PATH", "")
+    config_url_value = environment.get("SEGMENTER_MODEL_CONFIG_URL", "")
 
     assert CONTAINER_MODEL_PATH_DEFAULT in path_value
+    assert CONTAINER_CONFIG_PATH_DEFAULT in config_path_value
     assert path_value.startswith("${SEGMENTER_MODEL_PATH:-")
+    assert config_path_value.startswith("${SEGMENTER_MODEL_CONFIG_PATH:-")
     assert url_value.startswith("${SEGMENTER_MODEL_URL:-https://")
-    assert url_value.endswith("semantic_segmenter.onnx}")
+    assert config_url_value.startswith("${SEGMENTER_MODEL_CONFIG_URL:-https://")
+    assert url_value.endswith("best.safetensors}")
+    assert config_url_value.endswith("config.yaml}")
 
 
 def test_compose_worker_mounts_models_volume() -> None:
@@ -79,13 +96,17 @@ def test_compose_worker_mounts_models_volume() -> None:
 
 def test_settings_expose_segmenter_model_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Settings surface SEGMENTER_MODEL_PATH/URL from the environment."""
-    monkeypatch.setenv("SEGMENTER_MODEL_PATH", "./models/semantic_segmenter.onnx")
-    monkeypatch.setenv("SEGMENTER_MODEL_URL", "https://example.com/semantic_segmenter.onnx")
+    monkeypatch.setenv("SEGMENTER_MODEL_PATH", "./models/best.safetensors")
+    monkeypatch.setenv("SEGMENTER_MODEL_URL", "https://example.com/best.safetensors")
+    monkeypatch.setenv("SEGMENTER_MODEL_CONFIG_PATH", "./models/config.yaml")
+    monkeypatch.setenv("SEGMENTER_MODEL_CONFIG_URL", "https://example.com/config.yaml")
     get_settings.cache_clear()
 
     try:
         settings = get_settings()
-        assert settings.SEGMENTER_MODEL_PATH == "./models/semantic_segmenter.onnx"
-        assert settings.SEGMENTER_MODEL_URL == "https://example.com/semantic_segmenter.onnx"
+        assert settings.SEGMENTER_MODEL_PATH == "./models/best.safetensors"
+        assert settings.SEGMENTER_MODEL_URL == "https://example.com/best.safetensors"
+        assert settings.SEGMENTER_MODEL_CONFIG_PATH == "./models/config.yaml"
+        assert settings.SEGMENTER_MODEL_CONFIG_URL == "https://example.com/config.yaml"
     finally:
         get_settings.cache_clear()

--- a/backend/tests/test_model_provisioning.py
+++ b/backend/tests/test_model_provisioning.py
@@ -12,6 +12,7 @@ import cv2
 import numpy as np
 import pytest
 
+from app.ml import download_model as download_model_cli
 from app.ml import segmentation_model
 from app.ml.segmentation_model import (
     MAX_MODEL_SIZE_BYTES,
@@ -21,6 +22,7 @@ from app.ml.segmentation_model import (
     provision_segmentation_model,
     validate_segmentation_model,
 )
+from app.ml.yytsi_torch import YYTSI_CONFIG_FILENAME, YYTSI_MODEL_FILENAME
 from app.pipeline import PipelineContext, SegmenterStep
 from app.pipeline.steps.segmenter import MASK_LABELS, OnnxSemanticSegmenter
 
@@ -214,6 +216,20 @@ def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _write_yytsi_config(path: Path, *, image_size: tuple[int, int] = (128, 128)) -> Path:
+    path.write_text(
+        "data:\n"
+        f"  image_size: [{image_size[0]}, {image_size[1]}]\n"
+        "  normalize: true\n"
+        "  letterbox: true\n"
+        "model:\n"
+        "  encoder_name: resnet34\n"
+        "  encoder_weights: null\n",
+        encoding="utf-8",
+    )
+    return path
+
+
 def test_cli_provisions_reference_model(tmp_path: Path) -> None:
     """`python -m app.ml.download_model` provisions a valid model and reports it."""
     result = _run_cli("--models-dir", str(tmp_path))
@@ -259,6 +275,91 @@ def test_cli_force_replaces_corrupt_model(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stderr
     assert validate_segmentation_model(destination).passed
+
+
+def test_cli_check_validates_existing_yytsi_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`--check` validates a `.safetensors + config.yaml` Torch bundle."""
+    weights_path = tmp_path / YYTSI_MODEL_FILENAME
+    weights_path.write_text("weights", encoding="utf-8")
+    _write_yytsi_config(tmp_path / YYTSI_CONFIG_FILENAME)
+
+    def fake_validate(*, weights_path: Path | str, config_path: Path | str, input_size: int):
+        class Report:
+            passed = True
+
+            @staticmethod
+            def summary() -> str:
+                return (
+                    f"weights path:   {weights_path}\n"
+                    f"config path:    {config_path}\n"
+                    f"input size:     {input_size}"
+                )
+
+        return Report()
+
+    monkeypatch.setattr("app.ml.download_model.validate_yytsi_bundle", fake_validate)
+
+    exit_code = download_model_cli.main(
+        ["--check", "--models-dir", str(tmp_path), "--filename", YYTSI_MODEL_FILENAME]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "weights path:" in captured.out
+    assert "config path:" in captured.out
+    assert "result: PASS" in captured.out
+
+
+def test_cli_provisions_yytsi_bundle_with_config_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Provisioning a `.safetensors` bundle resolves both weights and config."""
+
+    def fake_resolve(**kwargs: object) -> tuple[Path, Path]:
+        model_path = Path(str(kwargs["model_path"]))
+        config_path = Path(str(kwargs["config_path"]))
+        model_path.parent.mkdir(parents=True, exist_ok=True)
+        model_path.write_text("weights", encoding="utf-8")
+        _write_yytsi_config(config_path)
+        return model_path, config_path
+
+    def fake_validate(*, weights_path: Path | str, config_path: Path | str, input_size: int):
+        class Report:
+            passed = True
+
+            @staticmethod
+            def summary() -> str:
+                return (
+                    f"weights path:   {weights_path}\n"
+                    f"config path:    {config_path}\n"
+                    f"configured input size: {input_size}"
+                )
+
+        return Report()
+
+    monkeypatch.setattr("app.ml.download_model.resolve_yytsi_model_assets", fake_resolve)
+    monkeypatch.setattr("app.ml.download_model.validate_yytsi_bundle", fake_validate)
+
+    exit_code = download_model_cli.main(
+        [
+            "--models-dir",
+            str(tmp_path),
+            "--filename",
+            YYTSI_MODEL_FILENAME,
+            "--url",
+            "https://example.com/best.safetensors",
+            "--config-url",
+            "https://example.com/config.yaml",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert (tmp_path / YYTSI_MODEL_FILENAME).is_file()
+    assert (tmp_path / YYTSI_CONFIG_FILENAME).is_file()
+    assert "result: PASS" in captured.out
 
 
 def test_segmenter_step_runs_ml_path_with_provisioned_model(tmp_path: Path) -> None:

--- a/backend/tests/test_worker_model_preload.py
+++ b/backend/tests/test_worker_model_preload.py
@@ -50,7 +50,7 @@ def test_worker_preload_handler_is_registered_on_worker_process_init() -> None:
 def test_worker_startup_loads_configured_model_without_errors(
     worker_startup_state: pytest.MonkeyPatch,
 ) -> None:
-    """AC: worker loads the model on startup when SEGMENTER_MODEL_PATH is set."""
+    """AC: worker preloads the configured ONNX backend on startup."""
     worker_startup_state.setenv("SEGMENTER_MODEL_PATH", str(BUNDLED_MODEL_PATH))
     worker_startup_state.delenv("SEGMENTER_MODEL_URL", raising=False)
 
@@ -78,7 +78,7 @@ def test_worker_startup_preload_is_cached_per_process(
 def test_worker_startup_is_noop_without_model_config(
     worker_startup_state: pytest.MonkeyPatch,
 ) -> None:
-    """Workers without model configuration start without touching ONNX Runtime."""
+    """Workers without model configuration start without touching model caches."""
     worker_startup_state.delenv("SEGMENTER_MODEL_PATH", raising=False)
     worker_startup_state.delenv("SEGMENTER_MODEL_URL", raising=False)
 
@@ -102,4 +102,34 @@ def test_worker_startup_with_missing_model_path_does_not_load_session(
 
     _send_worker_process_init()
 
+    assert _get_onnx_session.cache_info().currsize == 0
+
+
+def test_worker_startup_preloads_torch_bundle_without_touching_onnx_cache(
+    worker_startup_state: pytest.MonkeyPatch,
+) -> None:
+    """Workers preload the Torch Yytsi backend when configured with `.safetensors`."""
+    worker_startup_state.setenv("SEGMENTER_MODEL_PATH", "/tmp/models/best.safetensors")
+    worker_startup_state.setenv("SEGMENTER_MODEL_CONFIG_PATH", "/tmp/models/config.yaml")
+    worker_startup_state.delenv("SEGMENTER_MODEL_URL", raising=False)
+    worker_startup_state.delenv("SEGMENTER_MODEL_CONFIG_URL", raising=False)
+
+    calls: list[tuple[str, str]] = []
+
+    def fake_get_yytsi_model(weights_path: str, config_path: str) -> object:
+        calls.append((weights_path, config_path))
+        return object()
+
+    worker_startup_state.setattr(
+        "app.pipeline.steps.segmenter.resolve_yytsi_model_assets",
+        lambda **_: (Path("/tmp/models/best.safetensors"), Path("/tmp/models/config.yaml")),
+    )
+    worker_startup_state.setattr(
+        "app.pipeline.steps.segmenter.get_yytsi_model",
+        fake_get_yytsi_model,
+    )
+
+    _send_worker_process_init()
+
+    assert calls == [("/tmp/models/best.safetensors", "/tmp/models/config.yaml")]
     assert _get_onnx_session.cache_info().currsize == 0

--- a/backend/tests/test_yytsi_torch_segmenter.py
+++ b/backend/tests/test_yytsi_torch_segmenter.py
@@ -1,0 +1,177 @@
+"""Tests for the Docker-bundled Yytsi Torch segmenter path."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from app.ml.yytsi_torch import (
+    YYTSI_CONFIG_FILENAME,
+    YYTSI_MEAN_RGB_255,
+    YytsiModelConfig,
+    decode_yytsi_predictions,
+    infer_yytsi_config_url,
+    load_yytsi_config,
+    prepare_yytsi_input,
+    resolve_yytsi_model_assets,
+)
+from app.pipeline.steps.segmenter import MASK_LABELS, TorchYytsiSegmenter
+
+
+def _write_config(path: Path, *, image_size: tuple[int, int] = (512, 512)) -> Path:
+    path.write_text(
+        "data:\n"
+        f"  image_size: [{image_size[0]}, {image_size[1]}]\n"
+        "  normalize: true\n"
+        "  letterbox: true\n"
+        "model:\n"
+        "  encoder_name: resnet34\n"
+        "  encoder_weights: imagenet\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _preprocessed_floor_plan() -> np.ndarray:
+    image = np.zeros((240, 320), dtype=np.uint8)
+    # structural foreground (white on black, like OpenCVPreprocessor output)
+    image[30:210, 30:36] = 255
+    image[30:210, 284:290] = 255
+    image[30:36, 30:290] = 255
+    image[204:210, 30:290] = 255
+    image[80:86, 160:220] = 255
+    # text-like blobs away from walls/openings
+    image[180:188, 90:110] = 255
+    image[180:188, 116:136] = 255
+    return image
+
+
+def test_infer_yytsi_config_url_swaps_weights_filename() -> None:
+    url = "https://huggingface.co/Yytsi/floorplan-to-3d-walls/resolve/main/best.safetensors"
+
+    assert infer_yytsi_config_url(url).endswith("/config.yaml")
+
+
+def test_load_yytsi_config_reads_runtime_fields(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path / YYTSI_CONFIG_FILENAME, image_size=(512, 512))
+
+    config = load_yytsi_config(config_path)
+
+    assert config == YytsiModelConfig(
+        image_size=(512, 512),
+        normalize=True,
+        letterbox=True,
+        encoder_name="resnet34",
+        encoder_weights="imagenet",
+    )
+
+
+def test_prepare_yytsi_input_letterboxes_binary_foreground() -> None:
+    image = _preprocessed_floor_plan()
+
+    chw, rect = prepare_yytsi_input(
+        image,
+        image_size=(512, 512),
+        normalize=False,
+        letterbox=True,
+    )
+
+    assert chw.shape == (3, 512, 512)
+    left, top, inner_w, inner_h = rect
+    assert inner_w == 512
+    assert inner_h < 512
+    background_value = np.asarray(YYTSI_MEAN_RGB_255, dtype=np.float32) / 255.0
+    assert np.allclose(chw[:, 0, 0], background_value, atol=1e-3)
+    assert np.min(chw[:, top : top + inner_h, left : left + inner_w]) == 0.0
+
+
+def test_decode_yytsi_predictions_preserves_five_label_contract() -> None:
+    class_map = np.zeros((512, 512), dtype=np.uint8)  # floor background
+    class_map[40:470, 40:48] = 1  # wall
+    class_map[40:470, 464:472] = 1
+    class_map[40:48, 40:472] = 1
+    class_map[464:472, 40:472] = 1
+    class_map[180:200, 248:292] = 2  # door
+    class_map[56:72, 312:392] = 3  # window
+
+    masks = decode_yytsi_predictions(
+        class_map=class_map,
+        original_image=_preprocessed_floor_plan(),
+        original_shape=(240, 320),
+        content_rect=(0, 64, 512, 384),
+        mask_labels=MASK_LABELS,
+    )
+
+    assert set(masks) == set(MASK_LABELS)
+    for label in MASK_LABELS:
+        assert len(masks[label]) == 1
+        assert masks[label][0].shape == (240, 320)
+        assert np.count_nonzero(masks[label][0]) > 0, f"missing {label}"
+
+
+def test_resolve_yytsi_model_assets_downloads_config_beside_weights(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    downloads: list[tuple[str, Path]] = []
+
+    def fake_download(url: str, destination: Path | str) -> Path:
+        path = Path(destination)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("stub", encoding="utf-8")
+        downloads.append((url, path))
+        return path
+
+    monkeypatch.setattr("app.ml.yytsi_torch.download_segmentation_model", fake_download)
+
+    weights_path, config_path = resolve_yytsi_model_assets(
+        model_path=tmp_path / "best.safetensors",
+        model_url="https://huggingface.co/Yytsi/floorplan-to-3d-walls/resolve/main/best.safetensors",
+    )
+
+    assert weights_path.is_file()
+    assert config_path.is_file()
+    assert config_path.name == "config.yaml"
+    assert downloads[0][0].endswith("best.safetensors")
+    assert downloads[1][0].endswith("config.yaml")
+
+
+def test_torch_segmenter_uses_config_image_size_when_input_size_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import torch
+
+    weights_path = tmp_path / "best.safetensors"
+    weights_path.write_text("weights", encoding="utf-8")
+    config_path = _write_config(tmp_path / "config.yaml", image_size=(512, 512))
+
+    class FakeModel:
+        def eval(self) -> FakeModel:
+            return self
+
+        def __call__(self, tensor: torch.Tensor) -> torch.Tensor:
+            _, _channels, height, width = tensor.shape
+            output = torch.zeros((1, 4, height, width), dtype=torch.float32)
+            output[:, 1, 100:420, 60:68] = 10.0  # left wall
+            output[:, 1, 100:420, 444:452] = 10.0  # right wall
+            output[:, 1, 100:108, 60:452] = 10.0  # top wall
+            output[:, 1, 412:420, 60:452] = 10.0  # bottom wall
+            output[:, 2, 220:250, 220:280] = 10.0  # door
+            output[:, 3, 140:156, 300:380] = 10.0  # window
+            return output
+
+    monkeypatch.setattr(
+        "app.pipeline.steps.segmenter.get_yytsi_model",
+        lambda weights, config: FakeModel(),
+    )
+
+    segmenter = TorchYytsiSegmenter(model_path=weights_path, config_path=config_path)
+    masks = segmenter.segment([_preprocessed_floor_plan()])
+
+    assert set(masks) == set(MASK_LABELS)
+    assert np.count_nonzero(masks["walls"][0]) > 0
+    assert np.count_nonzero(masks["doors"][0]) > 0
+    assert np.count_nonzero(masks["windows"][0]) > 0
+    assert np.count_nonzero(masks["rooms"][0]) > 0
+    assert np.count_nonzero(masks["text"][0]) > 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,11 @@ services:
       STORAGE_PATH: ${STORAGE_PATH:-/app/storage}
       STORAGE_TTL_DAYS: 7
       MODELS_PATH: ${MODELS_PATH:-/app/models}
-      SEGMENTER_MODEL_PATH: ${SEGMENTER_MODEL_PATH:-/app/models/semantic_segmenter.onnx}
-      SEGMENTER_MODEL_URL: ${SEGMENTER_MODEL_URL:-https://raw.githubusercontent.com/Josh-Uvi/DrawLift/main/backend/models/semantic_segmenter.onnx}
+      SEGMENTER_MODEL_PATH: ${SEGMENTER_MODEL_PATH:-/app/models/best.safetensors}
+      SEGMENTER_MODEL_CONFIG_PATH: ${SEGMENTER_MODEL_CONFIG_PATH:-/app/models/config.yaml}
+      SEGMENTER_MODEL_URL: ${SEGMENTER_MODEL_URL:-https://huggingface.co/Yytsi/floorplan-to-3d-walls/resolve/main/best.safetensors}
+      SEGMENTER_MODEL_CONFIG_URL: ${SEGMENTER_MODEL_CONFIG_URL:-https://huggingface.co/Yytsi/floorplan-to-3d-walls/resolve/main/config.yaml}
+      SEGMENTER_MODEL_INPUT_SIZE: ${SEGMENTER_MODEL_INPUT_SIZE:-512}
       PATH: /opt/libredwg/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       LD_LIBRARY_PATH: /opt/libredwg/lib
       DWG_CONVERTER_COMMAND: ${DWG_CONVERTER_COMMAND:-dwgwrite {input} {output}}
@@ -64,8 +67,11 @@ services:
       STORAGE_PATH: ${STORAGE_PATH:-/app/storage}
       STORAGE_TTL_DAYS: 7
       MODELS_PATH: ${MODELS_PATH:-/app/models}
-      SEGMENTER_MODEL_PATH: ${SEGMENTER_MODEL_PATH:-/app/models/semantic_segmenter.onnx}
-      SEGMENTER_MODEL_URL: ${SEGMENTER_MODEL_URL:-https://raw.githubusercontent.com/Josh-Uvi/DrawLift/main/backend/models/semantic_segmenter.onnx}
+      SEGMENTER_MODEL_PATH: ${SEGMENTER_MODEL_PATH:-/app/models/best.safetensors}
+      SEGMENTER_MODEL_CONFIG_PATH: ${SEGMENTER_MODEL_CONFIG_PATH:-/app/models/config.yaml}
+      SEGMENTER_MODEL_URL: ${SEGMENTER_MODEL_URL:-https://huggingface.co/Yytsi/floorplan-to-3d-walls/resolve/main/best.safetensors}
+      SEGMENTER_MODEL_CONFIG_URL: ${SEGMENTER_MODEL_CONFIG_URL:-https://huggingface.co/Yytsi/floorplan-to-3d-walls/resolve/main/config.yaml}
+      SEGMENTER_MODEL_INPUT_SIZE: ${SEGMENTER_MODEL_INPUT_SIZE:-512}
       PATH: /opt/libredwg/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       LD_LIBRARY_PATH: /opt/libredwg/lib
       DWG_CONVERTER_COMMAND: ${DWG_CONVERTER_COMMAND:-dwgwrite {input} {output}}
@@ -92,8 +98,11 @@ services:
       STORAGE_PATH: ${STORAGE_PATH:-/app/storage}
       STORAGE_TTL_DAYS: 7
       MODELS_PATH: ${MODELS_PATH:-/app/models}
-      SEGMENTER_MODEL_PATH: ${SEGMENTER_MODEL_PATH:-/app/models/semantic_segmenter.onnx}
-      SEGMENTER_MODEL_URL: ${SEGMENTER_MODEL_URL:-https://raw.githubusercontent.com/Josh-Uvi/DrawLift/main/backend/models/semantic_segmenter.onnx}
+      SEGMENTER_MODEL_PATH: ${SEGMENTER_MODEL_PATH:-/app/models/best.safetensors}
+      SEGMENTER_MODEL_CONFIG_PATH: ${SEGMENTER_MODEL_CONFIG_PATH:-/app/models/config.yaml}
+      SEGMENTER_MODEL_URL: ${SEGMENTER_MODEL_URL:-https://huggingface.co/Yytsi/floorplan-to-3d-walls/resolve/main/best.safetensors}
+      SEGMENTER_MODEL_CONFIG_URL: ${SEGMENTER_MODEL_CONFIG_URL:-https://huggingface.co/Yytsi/floorplan-to-3d-walls/resolve/main/config.yaml}
+      SEGMENTER_MODEL_INPUT_SIZE: ${SEGMENTER_MODEL_INPUT_SIZE:-512}
       PATH: /opt/libredwg/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       LD_LIBRARY_PATH: /opt/libredwg/lib
       DWG_CONVERTER_COMMAND: ${DWG_CONVERTER_COMMAND:-dwgwrite {input} {output}}

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -528,7 +528,7 @@
 
 # Stage 6 — ML Model & DWG Converter
 
-> **Goal:** Acquire a pre-trained ONNX floor-plan segmentation model, wire it into the ML segmenter path, and build a `libredwg` Docker sidecar for true DXF→DWG conversion. These are the two critical blockers preventing the pipeline from producing production-quality output.
+> **Goal:** Acquire a production-ready floor-plan segmentation model, wire it into the ML segmenter path, and build a `libredwg` Docker sidecar for true DXF→DWG conversion. These are the two critical blockers preventing the pipeline from producing production-quality output.
 
 ## Epic 6.1 — ML Model Acquisition
 
@@ -562,7 +562,7 @@
   - [x] T-099 — Verify ONNX inference input/output tensor shapes match `OnnxSemanticSegmenter` expectations
   - [x] T-100 — Add integration test for ML segmenter with real model file
 - **Implementation notes:**
-  - `.env.example` and the `backend`/`worker`/`beat` Compose services set `SEGMENTER_MODEL_PATH` plus a `SEGMENTER_MODEL_URL` auto-download fallback (the reference model served from this repository's `main` branch), so fresh Docker models volumes self-provision. Celery workers preload the configured model via a `worker_process_init` signal handler. Integration tests draw floor plans into real PDFs and run PDF parsing → preprocessing → ML segmentation end to end.
+  - Follow-up Torch wiring now defaults Docker/runtime environments to the `Yytsi/floorplan-to-3d-walls` bundle (`best.safetensors` + `config.yaml`) via `SEGMENTER_MODEL_PATH`, `SEGMENTER_MODEL_CONFIG_PATH`, `SEGMENTER_MODEL_URL`, and `SEGMENTER_MODEL_CONFIG_URL`. `AutoMlSegmenter` dispatches by file extension (`.onnx` → ONNX Runtime, `.safetensors` → Torch/Yytsi), and Celery workers preload the configured backend via `worker_process_init` so configuration errors surface on startup.
 
 ### US-031 · As a user, I want ML segmentation producing all five mask classes
 
@@ -577,7 +577,7 @@
   - [x] T-102 — Update `SEGMENTER_MODEL_INPUT_SIZE` if model requires different resolution (e.g. 256×256 for CubiCasa5K)
   - [x] T-103 — Compare classic vs ML output quality on sample floor plan and document results
 - **Implementation notes:**
-  - The bundled reference model emits all five labels for floor plans containing walls, doors, windows, and text; `app.ml.comparison.compare_segmenters` produces reproducible per-label coverage/reporting. `check_model_input_size` verifies the configured `SEGMENTER_MODEL_INPUT_SIZE` against a model's declared input dims (and `make validate-model` reports it). The full PDF→DXF pipeline with `segmenter: "ml"` emits DOORS/WINDOWS/TEXT entities, which the classic backend cannot produce. See [Classic vs ML comparison](./pipeline.md#classic-vs-ml-segmentation-comparison).
+  - The Yytsi Torch bundle predicts four structural classes (`floor`, `wall`, `door`, `window`). The backend preserves the existing five-class contract by deriving `rooms` from structural masks and heuristically provisioning `text` from residual foreground blobs. `SEGMENTER_MODEL_INPUT_SIZE=512` now matches the published Yytsi bundle defaults, while the legacy ONNX path remains available as a compatibility fallback. The full PDF→DXF pipeline with `segmenter: "ml"` continues to emit DOORS/WINDOWS/TEXT entities, which the classic backend cannot produce. See [Classic vs ML comparison](./pipeline.md#classic-vs-ml-segmentation-comparison).
 
 ## Epic 6.3 — DWG Converter Sidecar
 
@@ -864,4 +864,4 @@ Stage 6 (ML & DWG)                    ▼
 
 ---
 
-_Document version 1.3 — updated 2026-08-18: US-031 implemented (ML five-class masks, input-size validation, classic vs ML comparison documented, DXF entity coverage). US-001 ✅ Done; US-002 → US-031 👀 In Review; US-032 🟦 Todo._
+_Document version 1.4 — updated 2026-08-21: Docker/runtime ML defaults now use the Yytsi Torch bundle with five-class contract bridging, worker preload auto-selects ONNX vs Torch backends, and the full backend suite remains green. US-001 ✅ Done; US-002 → US-032 👀 In Review._

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -61,17 +61,34 @@ make download-model MODEL_URL=<url>       # download trained weights instead
 make validate-model                       # validate model contract + configured input size
 ```
 
-Every provisioned artifact is validated (exists, <100 MB, CPU-only ONNX
-Runtime load, 5-class decodable output). `make validate-model` also verifies
-that the configured `SEGMENTER_MODEL_INPUT_SIZE` matches the model's declared
-input dimensions. Invalid downloads are removed.
+Every provisioned artifact is validated. ONNX artifacts are checked for
+existence, <100 MB size, CPU-only ONNX Runtime loading, and 5-class decodable
+output; Torch Yytsi bundles validate the paired `best.safetensors` +
+`config.yaml` assets, confirm the configured input size matches the bundle, and
+exercise CPU inference. Invalid downloads are removed.
 
-`SEGMENTER_MODEL_PATH` and `SEGMENTER_MODEL_URL` are set by default in
-`.env.example` and `docker-compose.yml`; the URL is used as an auto-download
-fallback when the model file is missing (e.g. a fresh Docker models volume).
-Celery workers preload the configured model once per process at startup
-(`worker_process_init`), so misconfiguration surfaces in worker logs
+Docker/runtime defaults now point at the Yytsi Hugging Face bundle:
+
+- `SEGMENTER_MODEL_PATH=./models/best.safetensors`
+- `SEGMENTER_MODEL_CONFIG_PATH=./models/config.yaml`
+- `SEGMENTER_MODEL_URL=https://huggingface.co/Yytsi/floorplan-to-3d-walls/.../best.safetensors`
+- `SEGMENTER_MODEL_CONFIG_URL=https://huggingface.co/Yytsi/floorplan-to-3d-walls/.../config.yaml`
+- `SEGMENTER_MODEL_INPUT_SIZE=512`
+
+Celery workers preload the configured ML backend once per process at startup
+(`worker_process_init`), so ONNX/Torch misconfiguration surfaces in worker logs
 immediately.
+
+To provision the Yytsi bundle manually from the backend package root:
+
+```bash
+python -m app.ml.download_model \
+  --models-dir ./models \
+  --filename best.safetensors \
+  --config-filename config.yaml \
+  --url https://huggingface.co/Yytsi/floorplan-to-3d-walls/resolve/main/best.safetensors \
+  --config-url https://huggingface.co/Yytsi/floorplan-to-3d-walls/resolve/main/config.yaml
+```
 
 ## Hybrid local workflow
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -86,15 +86,15 @@ DXF outputs use domain-oriented layers such as:
 
 | Aspect | `classic` | `ml` |
 | --- | --- | --- |
-| Walls | ✅ Detected via Canny + Hough lines | ⚠️ Requires ONNX model (not yet bundled) |
-| Doors | ❌ Always zero mask | ⚠️ Requires ONNX model |
-| Windows | ❌ Always zero mask | ⚠️ Requires ONNX model |
-| Rooms | ✅ Derived from wall mask regions | ⚠️ Requires ONNX model |
-| Text | ❌ Always zero mask | ⚠️ Requires ONNX model |
+| Walls | ✅ Detected via Canny + Hough lines | ✅ Default Yytsi Torch bundle predicts walls |
+| Doors | ❌ Always zero mask | ✅ Default Yytsi Torch bundle predicts doors |
+| Windows | ❌ Always zero mask | ✅ Default Yytsi Torch bundle predicts windows |
+| Rooms | ✅ Derived from wall mask regions | ✅ Derived from Yytsi structural masks |
+| Text | ❌ Always zero mask | ✅ Heuristically recovered from residual foreground |
 
 The `classic` segmenter uses thresholding, Canny edges, and probabilistic Hough line detection. It detects wall structures but emits zero-filled masks for doors, windows, and text. This means downstream vectorization and DXF output are structurally valid but semantically incomplete for real architectural drawings.
 
-The `ml` segmenter supports ONNX Runtime inference and produces all five mask classes when a suitable model is configured. `backend/models/semantic_segmenter.onnx` ships a small deterministic reference model (edge-energy segmentation expressed as ONNX ops) that satisfies the segmenter contract so the ML path works out of the box. `SEGMENTER_MODEL_PATH` and `SEGMENTER_MODEL_URL` are configured by default in `.env.example` and `docker-compose.yml` (US-030): the URL acts as an auto-download fallback for fresh Docker model volumes, and Celery workers preload the configured model at startup via a `worker_process_init` handler. Trained weights can replace the reference model via `make download-model MODEL_URL=<url>` or `SEGMENTER_MODEL_URL`; every provisioned artifact is validated against the US-029 contract (CPU-only load, <100 MB, 5-class decodable output) by `app.ml.segmentation_model`. See [Stage 6 in TODO.md](./TODO.md) for the model acquisition plan.
+The `ml` segmenter now supports both ONNX Runtime inference and Torch bundle inference via `AutoMlSegmenter`. Docker/runtime defaults target the `Yytsi/floorplan-to-3d-walls` bundle (`best.safetensors` + `config.yaml`), which predicts four structural classes and is bridged back to the pipeline's stable five-label contract by deriving `rooms` and heuristically provisioning `text`. The legacy `backend/models/semantic_segmenter.onnx` reference model remains available as a compatibility fallback and for contract-validation utilities. `.env.example` and `docker-compose.yml` set `SEGMENTER_MODEL_PATH`, `SEGMENTER_MODEL_CONFIG_PATH`, `SEGMENTER_MODEL_URL`, and `SEGMENTER_MODEL_CONFIG_URL` by default; Celery workers preload whichever backend is configured via the `worker_process_init` handler. See [Stage 6 in TODO.md](./TODO.md) for the model acquisition plan.
 
 ## Classic vs ML segmentation comparison
 
@@ -113,9 +113,9 @@ Representative sample: a 240×320 floor plan containing exterior/interior walls,
 Observations:
 
 - The `classic` backend still provides structurally useful wall masks, but it cannot emit door, window, or text masks, so downstream DXF output lacks those semantic entities.
-- The bundled `ml` reference model activates all five labels on the same drawing and produces multiple vectorizable connected components for doors, windows, and text.
+- The default Yytsi-backed `ml` path activates all five labels on the same drawing and produces multiple vectorizable connected components for doors, windows, and text.
 - With the same fixture routed through the full PDF→DXF pipeline, the ML path emits entities on `DOORS`, `WINDOWS`, `ROOMS`, and `TEXT` layers; the classic path emits only `WALLS`.
-- The bundled reference model remains a deterministic edge-energy heuristic, not a trained floor-plan model. These numbers therefore prove the **5-label contract and DXF-layer plumbing**, not production-grade semantic accuracy.
+- The ONNX reference model remains available for contract validation, but the default Docker/runtime ML path now uses the trained Yytsi structural model with backend-specific post-processing for rooms/text. These numbers therefore prove the **5-label contract and DXF-layer plumbing**, while still depending on heuristic bridging for the two non-structural classes.
 
 Recommended lightweight open-source models for floor-plan segmentation:
 


### PR DESCRIPTION
This PR adds a Torch-based ML backend using the `Yytsi/floorplan-to-3d-walls` model and wires it into the Docker worker/runtime path.

### Highlights
- Adds support for loading `best.safetensors` + `config.yaml`
- Introduces automatic ML backend selection:
  - `.onnx` → ONNX Runtime
  - `.safetensors` → Torch/Yytsi
- Preserves the existing 5-class pipeline contract by:
  - using model output for `walls`, `doors`, `windows`
  - deriving `rooms`
  - heuristically recovering `text`
- Updates Docker/env defaults to use the Yytsi bundle
- Updates worker preload to initialize the configured ML backend on startup
- Adds test coverage for bundle provisioning, env wiring, backend selection, Torch inference path, and worker preload
- Fixes pre-commit so frontend dependencies auto-bootstrap when missing
